### PR TITLE
Add katex header & bump libs version

### DIFF
--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -19,7 +19,7 @@ jobs:
         crate: cargo-rdme
     - name: Check that readme matches lib.rs
       run: |
-        cargo rdme -w generic-ec -r README.md --check
-        cargo rdme -w generic-ec-zkp -r generic-ec-zkp/README.md --check
-        cargo rdme -w generic-ec-curves -r generic-ec-curves/README.md --check
-        cargo rdme -w generic-ec-core -r generic-ec-core/README.md --check
+        (cd generic-ec; cargo rdme -r ../README.md --check)
+        (cd generic-ec-zkp; cargo rdme -r README.md --check)
+        (cd generic-ec-curves; cargo rdme -r README.md --check)
+        (cd generic-ec-core; cargo rdme -r README.md --check)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
   "generic-ec",
   "generic-ec-core",

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ docs-private:
 	RUSTDOCFLAGS="--html-in-header katex-header.html --cfg docsrs" cargo +nightly doc --no-deps --all-features --document-private-items
 
 readme:
-	cargo rdme -w generic-ec -r README.md
-	cargo rdme -w generic-ec-core -r generic-ec-core/README.md
-	cargo rdme -w generic-ec-curves -r generic-ec-curves/README.md
-	cargo rdme -w generic-ec-zkp -r generic-ec-zkp/README.md
+	(cd generic-ec; cargo rdme -r ../README.md)
+	(cd generic-ec-core; cargo rdme -r README.md)
+	(cd generic-ec-curves; cargo rdme -r README.md)
+	(cd generic-ec-zkp; cargo rdme -r README.md)

--- a/README.md
+++ b/README.md
@@ -68,13 +68,15 @@ multiplying `NonZero<Point<E>>` at `NonZero<Scalar<E>>` returns `NonZero<Point<E
 
 Crate provides support for following elliptic curves out of box:
 
-| Curve      | Feature            | Backend           |
-|------------|--------------------|-------------------|
-| secp256k1  | `curve-secp256k1`  | [RustCrypto/k256] |
-| secp256r1  | `curve-secp256r1`  | [RustCrypto/p256] |
+| Curve        | Feature            | Backend           |
+|--------------|--------------------|-------------------|
+| secp256k1    | `curve-secp256k1`  | [RustCrypto/k256] |
+| secp256r1    | `curve-secp256r1`  | [RustCrypto/p256] |
+| stark-curve  | `curve-stark`      | [Dfns/stark]      |
 
 [RustCrypto/k256]: https://github.com/RustCrypto/elliptic-curves/tree/master/k256
 [RustCrypto/p256]: https://github.com/RustCrypto/elliptic-curves/tree/master/p256
+[Dfns/stark]: https://github.com/dfns/stark-curve/
 
 In order to use one of the supported curves, you need to turn on corresponding feature. E.g. if you want
 to use secp256k1 curve, add this to Cargo.toml:

--- a/generic-ec-core/Cargo.toml
+++ b/generic-ec-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generic-ec-core"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dfns/generic-ec"

--- a/generic-ec-core/Cargo.toml
+++ b/generic-ec-core/Cargo.toml
@@ -13,7 +13,7 @@ generic-array = "0.14"
 subtle = { version = "2.4", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 zeroize = { version = "1", default-features = false }
-serde = { version = "1", default-features = false, optional = true }
+serde = { version = "1", default-features = false, features = ["derive"], optional = true }
 
 [features]
 default = []

--- a/generic-ec-core/Cargo.toml
+++ b/generic-ec-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generic-ec-core"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dfns/generic-ec"

--- a/generic-ec-core/katex-header.html
+++ b/generic-ec-core/katex-header.html
@@ -1,0 +1,1 @@
+../katex-header.html

--- a/generic-ec-curves/Cargo.toml
+++ b/generic-ec-curves/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generic-ec-curves"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Elliptic curves for `generic-ec` crate"

--- a/generic-ec-curves/katex-header.html
+++ b/generic-ec-curves/katex-header.html
@@ -1,0 +1,1 @@
+../katex-header.html

--- a/generic-ec-zkp/Cargo.toml
+++ b/generic-ec-zkp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generic-ec-zkp"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dfns/generic-ec"

--- a/generic-ec-zkp/katex-header.html
+++ b/generic-ec-zkp/katex-header.html
@@ -1,0 +1,1 @@
+../katex-header.html

--- a/generic-ec/Cargo.toml
+++ b/generic-ec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generic-ec"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dfns/generic-ec"

--- a/generic-ec/Cargo.toml
+++ b/generic-ec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generic-ec"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dfns/generic-ec"

--- a/generic-ec/katex-header.html
+++ b/generic-ec/katex-header.html
@@ -1,0 +1,1 @@
+../katex-header.html

--- a/generic-ec/src/lib.rs
+++ b/generic-ec/src/lib.rs
@@ -66,13 +66,15 @@
 //!
 //! Crate provides support for following elliptic curves out of box:
 //!
-//! | Curve      | Feature            | Backend           |
-//! |------------|--------------------|-------------------|
-//! | secp256k1  | `curve-secp256k1`  | [RustCrypto/k256] |
-//! | secp256r1  | `curve-secp256r1`  | [RustCrypto/p256] |
+//! | Curve        | Feature            | Backend           |
+//! |--------------|--------------------|-------------------|
+//! | secp256k1    | `curve-secp256k1`  | [RustCrypto/k256] |
+//! | secp256r1    | `curve-secp256r1`  | [RustCrypto/p256] |
+//! | stark-curve  | `curve-stark`      | [Dfns/stark]      |
 //!
 //! [RustCrypto/k256]: https://github.com/RustCrypto/elliptic-curves/tree/master/k256
 //! [RustCrypto/p256]: https://github.com/RustCrypto/elliptic-curves/tree/master/p256
+//! [Dfns/stark]: https://github.com/dfns/stark-curve/
 //!
 //! In order to use one of the supported curves, you need to turn on corresponding feature. E.g. if you want
 //! to use secp256k1 curve, add this to Cargo.toml:


### PR DESCRIPTION
Fixes the build failure on docs.rs. Releases a new version of the lib `v0.1.1`