### PR TITLE
Publish generic-ec-curves v0.1.2: bump version

### DIFF
--- a/generic-ec-curves/Cargo.toml
+++ b/generic-ec-curves/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generic-ec-curves"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Elliptic curves for `generic-ec` crate"


### PR DESCRIPTION
We only introduced a new `ed25519` curve, that should only require a minor version bump