### PR TITLE
make getrandom behind the wasm feature flag

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -106,3 +106,16 @@ jobs:
         crate: wasm-pack
     - name: wasm-pack an example project
       run: (cd wasm/wasm-example; wasm-pack build)
+
+  build-wasm-nostd:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: Swatinem/rust-cache@v2
+      with:
+        cache-on-failure: "true"
+    - name: Install wasm32-unknown-unknown toolchain
+      run: rustup target add wasm32-unknown-unknown
+    - name: Build on wasm32-unknown-unknown (no_std)
+      run:
+        cargo build -p nostd-example --target wasm32-unknown-unknown

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,7 +44,7 @@ jobs:
       with:
         cache-on-failure: "true"
     - name: Run tests
-      run: cargo test --all-features
+      run: cargo test --all-features --exclude nostd-example
   fmt:
     runs-on: ubuntu-latest
     steps:
@@ -59,7 +59,7 @@ jobs:
       with:
         cache-on-failure: "true"
     - name: Run clippy
-      run: cargo clippy --all --lib --all-features --exclude generic-ec-tests -- --no-deps -D clippy::all -D clippy::unwrap_used -D clippy::expect_used
+      run: cargo clippy --all --lib --all-features --exclude generic-ec-tests --exclude nostd-example -- --no-deps -D clippy::all -D clippy::unwrap_used -D clippy::expect_used
   clippy-nostd:
     runs-on: ubuntu-latest
     steps:
@@ -77,7 +77,7 @@ jobs:
       with:
         cache-on-failure: "true"
     - name: Run clippy tests
-      run: cargo clippy --tests --all-features -- -D clippy::all
+      run: cargo clippy --tests --all-features --exclude nostd-example -- -D clippy::all
   check-doc:
     runs-on: ubuntu-latest
     steps:
@@ -87,7 +87,7 @@ jobs:
       with:
         cache-on-failure: "true"
     - name: Check docs
-      run: RUSTDOCFLAGS="--cfg docsrs -D warnings" cargo +nightly doc --all-features --no-deps
+      run: RUSTDOCFLAGS="--cfg docsrs -D warnings" cargo +nightly doc --all-features --no-deps --exclude nostd-example
   build-wasm:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,7 +59,7 @@ jobs:
       with:
         cache-on-failure: "true"
     - name: Run clippy
-      run: cargo clippy --all --lib --all-features --exclude generic-ec-tests --exclude nostd-example -- --no-deps -D clippy::all -D clippy::unwrap_used -D clippy::expect_used
+      run: cargo clippy --all --lib --workspace --all-features --exclude generic-ec-tests --exclude nostd-example -- --no-deps -D clippy::all -D clippy::unwrap_used -D clippy::expect_used
   clippy-nostd:
     runs-on: ubuntu-latest
     steps:
@@ -77,7 +77,7 @@ jobs:
       with:
         cache-on-failure: "true"
     - name: Run clippy tests
-      run: cargo clippy --tests --all-features --exclude nostd-example -- -D clippy::all
+      run: cargo clippy --workspace --tests --all-features --exclude nostd-example -- -D clippy::all
   check-doc:
     runs-on: ubuntu-latest
     steps:
@@ -87,7 +87,7 @@ jobs:
       with:
         cache-on-failure: "true"
     - name: Check docs
-      run: RUSTDOCFLAGS="--cfg docsrs -D warnings" cargo +nightly doc --all-features --no-deps --exclude nostd-example
+      run: RUSTDOCFLAGS="--cfg docsrs -D warnings" cargo +nightly doc --workspace --all-features --no-deps --exclude nostd-example
   build-wasm:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,7 +44,7 @@ jobs:
       with:
         cache-on-failure: "true"
     - name: Run tests
-      run: cargo test --all-features --exclude nostd-example
+      run: cargo test --all-features --workspace --exclude nostd-example
   fmt:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -99,7 +99,7 @@ jobs:
       run: rustup target add wasm32-unknown-unknown
     - name: Build on wasm32-unknown-unknown
       run:
-        cargo check -p generic-ec --target wasm32-unknown-unknown --features wasm,all-curves
+        cargo check -p generic-ec --target wasm32-unknown-unknown --features all-curves
     - name: Install wasm-pack
       uses: baptiste0928/cargo-install@v1
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,6 @@ members = [
   "generic-ec-curves",
   "generic-ec-zkp",
   "wasm/wasm-example",
+  "wasm/nostd",
   "tests",
 ]

--- a/generic-ec-curves/Cargo.toml
+++ b/generic-ec-curves/Cargo.toml
@@ -17,9 +17,9 @@ zeroize = { version = "1", default-features = false }
 
 crypto-bigint = { version = "0.5", optional = true }
 elliptic-curve = { version = "0.13", features = ["sec1", "hash2curve"], optional = true }
-k256 = { version = "0.13", optional = true, features = ["hash2curve"] }
-p256 = { version = "0.13", optional = true, features = ["hash2curve"] }
-sha2 = { version = "0.10", optional = true }
+k256 = { version = "0.13", optional = true, default-features = false, features = ["hash2curve"] }
+p256 = { version = "0.13", optional = true, default-features = false, features = ["hash2curve"] }
+sha2 = { version = "0.10", default-features = false, optional = true }
 stark-curve = { version = "0.1", optional = true }
 
 group = { version = "0.13", default-features = false, optional = true }

--- a/generic-ec-curves/Cargo.toml
+++ b/generic-ec-curves/Cargo.toml
@@ -15,7 +15,7 @@ subtle = { version = "2.4", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 zeroize = { version = "1", default-features = false }
 
-crypto-bigint = { version = "0.5", default-features = false, features = ["rand_core"], optional = true }
+crypto-bigint = { version = "0.5", default-features = false, optional = true }
 elliptic-curve = { version = "0.13", features = ["sec1", "hash2curve"], optional = true }
 k256 = { version = "0.13", optional = true, default-features = false, features = ["hash2curve"] }
 p256 = { version = "0.13", optional = true, default-features = false, features = ["hash2curve"] }

--- a/generic-ec-curves/Cargo.toml
+++ b/generic-ec-curves/Cargo.toml
@@ -16,9 +16,16 @@ rand_core = { version = "0.6", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 crypto-bigint = { version = "0.5", default-features = false, optional = true }
-elliptic-curve = { version = "0.13", default-features = false, features = ["sec1", "hash2curve"], optional = true }
-k256 = { version = "0.13", optional = true, default-features = false, features = ["hash2curve"] }
-p256 = { version = "0.13", optional = true, default-features = false, features = ["hash2curve"] }
+elliptic-curve = { version = "0.13", default-features = false, features = [
+    "sec1",
+    "hash2curve",
+], optional = true }
+k256 = { version = "0.13", optional = true, default-features = false, features = [
+    "hash2curve",
+] }
+p256 = { version = "0.13", optional = true, default-features = false, features = [
+    "hash2curve",
+] }
 sha2 = { version = "0.10", default-features = false, optional = true }
 stark-curve = { version = "0.1", default-features = false, optional = true }
 
@@ -33,7 +40,6 @@ optional = true
 
 [features]
 default = []
-std = []
 rust-crypto = ["elliptic-curve", "crypto-bigint"]
 secp256k1 = ["rust-crypto", "k256", "sha2"]
 secp256r1 = ["rust-crypto", "p256", "sha2"]

--- a/generic-ec-curves/Cargo.toml
+++ b/generic-ec-curves/Cargo.toml
@@ -16,16 +16,9 @@ rand_core = { version = "0.6", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 crypto-bigint = { version = "0.5", default-features = false, optional = true }
-elliptic-curve = { version = "0.13", default-features = false, features = [
-    "sec1",
-    "hash2curve",
-], optional = true }
-k256 = { version = "0.13", optional = true, default-features = false, features = [
-    "hash2curve",
-] }
-p256 = { version = "0.13", optional = true, default-features = false, features = [
-    "hash2curve",
-] }
+elliptic-curve = { version = "0.13", default-features = false, features = ["sec1", "hash2curve"], optional = true }
+k256 = { version = "0.13", optional = true, default-features = false, features = ["hash2curve"] }
+p256 = { version = "0.13", optional = true, default-features = false, features = ["hash2curve"] }
 sha2 = { version = "0.10", default-features = false, optional = true }
 stark-curve = { version = "0.1", default-features = false, optional = true }
 

--- a/generic-ec-curves/Cargo.toml
+++ b/generic-ec-curves/Cargo.toml
@@ -15,7 +15,7 @@ subtle = { version = "2.4", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 zeroize = { version = "1", default-features = false }
 
-crypto-bigint = { version = "0.5", optional = true }
+crypto-bigint = { version = "0.5", default-features = false, features = ["rand_core"], optional = true }
 elliptic-curve = { version = "0.13", features = ["sec1", "hash2curve"], optional = true }
 k256 = { version = "0.13", optional = true, default-features = false, features = ["hash2curve"] }
 p256 = { version = "0.13", optional = true, default-features = false, features = ["hash2curve"] }

--- a/generic-ec-curves/Cargo.toml
+++ b/generic-ec-curves/Cargo.toml
@@ -16,11 +16,11 @@ rand_core = { version = "0.6", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 crypto-bigint = { version = "0.5", default-features = false, optional = true }
-elliptic-curve = { version = "0.13", features = ["sec1", "hash2curve"], optional = true }
+elliptic-curve = { version = "0.13", default-features = false, features = ["sec1", "hash2curve"], optional = true }
 k256 = { version = "0.13", optional = true, default-features = false, features = ["hash2curve"] }
 p256 = { version = "0.13", optional = true, default-features = false, features = ["hash2curve"] }
 sha2 = { version = "0.10", default-features = false, optional = true }
-stark-curve = { version = "0.1", optional = true }
+stark-curve = { version = "0.1", default-features = false, optional = true }
 
 group = { version = "0.13", default-features = false, optional = true }
 

--- a/generic-ec-curves/Cargo.toml
+++ b/generic-ec-curves/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/dfns/generic-ec"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-generic-ec-core = "0.1"
+generic-ec-core = { version = "0.1", path = "../generic-ec-core", default-features = false }
 
 subtle = { version = "2.4", default-features = false }
 rand_core = { version = "0.6", default-features = false }

--- a/generic-ec-curves/Cargo.toml
+++ b/generic-ec-curves/Cargo.toml
@@ -33,7 +33,7 @@ optional = true
 
 [features]
 default = []
-
+std = []
 rust-crypto = ["elliptic-curve", "crypto-bigint"]
 secp256k1 = ["rust-crypto", "k256", "sha2"]
 secp256r1 = ["rust-crypto", "p256", "sha2"]

--- a/generic-ec-curves/src/ed25519.rs
+++ b/generic-ec-curves/src/ed25519.rs
@@ -124,7 +124,7 @@ impl core::cmp::Ord for Point {
 }
 
 impl core::hash::Hash for Point {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         self.0.compress().as_bytes().hash(state)
     }
 }

--- a/generic-ec-curves/src/lib.rs
+++ b/generic-ec-curves/src/lib.rs
@@ -6,6 +6,7 @@
 //! [`generic-ec` crate]: https://docs.rs/generic-ec
 
 #![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "ed25519")]
 pub mod ed25519;

--- a/generic-ec-curves/src/lib.rs
+++ b/generic-ec-curves/src/lib.rs
@@ -6,7 +6,7 @@
 //! [`generic-ec` crate]: https://docs.rs/generic-ec
 
 #![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 #[cfg(feature = "ed25519")]
 pub mod ed25519;

--- a/generic-ec-zkp/Cargo.toml
+++ b/generic-ec-zkp/Cargo.toml
@@ -18,7 +18,7 @@ udigest = { version = "0.1", features = ["derive"], optional = true }
 subtle = "2.4"
 rand_core = { version = "0.6", default-features = false }
 
-serde = { version = "1", default-features = false, features = ["derive"], optional = true }
+serde = { version = "1", default-features = false, features = ["derive", "alloc"], optional = true }
 
 # We don't depend on this crates directly, but need to specify features to make it compile
 generic-array = "0.14"

--- a/generic-ec-zkp/Cargo.toml
+++ b/generic-ec-zkp/Cargo.toml
@@ -18,7 +18,7 @@ udigest = { version = "0.1", features = ["derive"], optional = true }
 subtle = "2.4"
 rand_core = "0.6"
 
-serde = { version = "1", features = ["derive"], optional = true }
+serde = { version = "1", default-features = false, features = ["derive"], optional = true }
 
 # We don't depend on this crates directly, but need to specify features to make it compile
 generic-array = "0.14"

--- a/generic-ec-zkp/Cargo.toml
+++ b/generic-ec-zkp/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["elliptic-curves", "zk-proof"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-generic-ec = { version = "0.1", default-features = false }
+generic-ec = { version = "0.1", path = "../generic-ec", default-features = false }
 udigest = { version = "0.1", features = ["derive"], optional = true }
 
 subtle = "2.4"
@@ -30,7 +30,7 @@ sha2 = "0.10"
 
 generic-tests = "0.1"
 
-generic-ec = { version = "0.1", default-features = false, features = ["all-curves"] }
+generic-ec = { version = "0.1", path = "../generic-ec", default-features = false, features = ["all-curves"] }
 
 [features]
 default = ["std"]

--- a/generic-ec-zkp/Cargo.toml
+++ b/generic-ec-zkp/Cargo.toml
@@ -16,7 +16,7 @@ generic-ec = { version = "0.1", default-features = false }
 udigest = { version = "0.1", features = ["derive"], optional = true }
 
 subtle = "2.4"
-rand_core = "0.6"
+rand_core = { version = "0.6", default-features = false }
 
 serde = { version = "1", default-features = false, features = ["derive"], optional = true }
 

--- a/generic-ec-zkp/Cargo.toml
+++ b/generic-ec-zkp/Cargo.toml
@@ -15,10 +15,10 @@ keywords = ["elliptic-curves", "zk-proof"]
 generic-ec = { version = "0.1", path = "../generic-ec", default-features = false }
 udigest = { version = "0.1", features = ["derive"], optional = true }
 
-subtle = "2.4"
+subtle = { version = "2.4", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 
-serde = { version = "1", default-features = false, features = ["derive", "alloc"], optional = true }
+serde = { version = "1", default-features = false, features = ["derive"], optional = true }
 
 # We don't depend on this crates directly, but need to specify features to make it compile
 generic-array = "0.14"
@@ -35,7 +35,7 @@ generic-ec = { version = "0.1", path = "../generic-ec", default-features = false
 [features]
 default = ["std"]
 std = ["alloc"]
-alloc = ["udigest/alloc"]
+alloc = ["udigest?/alloc", "serde?/alloc"]
 serde = ["dep:serde", "generic-ec/serde", "generic-array/serde"]
 udigest = ["dep:udigest", "generic-ec/udigest"]
 

--- a/generic-ec/Cargo.toml
+++ b/generic-ec/Cargo.toml
@@ -13,8 +13,8 @@ keywords = ["elliptic-curves"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-generic-ec-core = "0.1"
-generic-ec-curves = { version = "0.1", optional = true }
+generic-ec-core = { version = "0.1", path = "../generic-ec-core" }
+generic-ec-curves = { version = "0.1", path = "../generic-ec-curves", optional = true }
 udigest = { version = "0.1", features = ["derive"], optional = true }
 
 subtle = { version = "2.4", default-features = false }

--- a/generic-ec/Cargo.toml
+++ b/generic-ec/Cargo.toml
@@ -27,9 +27,6 @@ hex = { version = "0.4", default-features = false, optional = true }
 
 phantom-type = { version = "0.4", default-features = false }
 
-# We don't depend on this crate directly, but we need to enable certain features when wasm is required
-getrandom = { version = "0.2", optional = true }
-
 [dev-dependencies]
 rand = "0.8"
 serde_json = "1"
@@ -48,8 +45,6 @@ curve-secp256r1 = ["curves", "generic-ec-curves/secp256r1"]
 curve-stark = ["curves", "generic-ec-curves/stark"]
 curve-ed25519 = ["curves", "generic-ec-curves/ed25519"]
 all-curves = ["curve-secp256k1", "curve-secp256r1", "curve-stark", "curve-ed25519"]
-
-wasm = ["getrandom/js"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/generic-ec/Cargo.toml
+++ b/generic-ec/Cargo.toml
@@ -28,7 +28,7 @@ hex = { version = "0.4", default-features = false, optional = true }
 phantom-type = { version = "0.4", default-features = false }
 
 # We don't depend on this crate directly, but we need to enable certain features when wasm is required
-getrandom = "0.2"
+getrandom = { version = "0.2", optional = true }
 
 [dev-dependencies]
 rand = "0.8"
@@ -47,7 +47,7 @@ curve-secp256k1 = ["curves", "generic-ec-curves/secp256k1"]
 curve-secp256r1 = ["curves", "generic-ec-curves/secp256r1"]
 curve-stark = ["curves", "generic-ec-curves/stark"]
 curve-ed25519 = ["curves", "generic-ec-curves/ed25519"]
-all-curves = ["curve-secp256k1", "curve-secp256r1", "curve-stark"]
+all-curves = ["curve-secp256k1", "curve-secp256r1", "curve-stark", "curve-ed25519"]
 
 wasm = ["getrandom/js"]
 

--- a/generic-ec/src/lib.rs
+++ b/generic-ec/src/lib.rs
@@ -208,7 +208,6 @@ pub mod traits {
     }
 }
 
-#[cfg(feature = "serde")]
 pub mod serde;
 
 pub use self::{

--- a/generic-ec/src/lib.rs
+++ b/generic-ec/src/lib.rs
@@ -213,6 +213,7 @@ pub mod traits {
     }
 }
 
+#[cfg(feature = "serde")]
 pub mod serde;
 
 pub use self::{

--- a/generic-ec/src/lib.rs
+++ b/generic-ec/src/lib.rs
@@ -182,11 +182,6 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-// We do not use getrandom directly, we just need to enable certain features
-// when `wasm` is required
-#[cfg(feature = "wasm")]
-use getrandom as _;
-
 pub use generic_ec_core as core;
 
 mod arithmetic;

--- a/generic-ec/src/lib.rs
+++ b/generic-ec/src/lib.rs
@@ -184,6 +184,7 @@ extern crate alloc;
 
 // We do not use getrandom directly, we just need to enable certain features
 // when `wasm` is required
+#[cfg(feature = "wasm")]
 use getrandom as _;
 
 pub use generic_ec_core as core;

--- a/generic-ec/src/serde.rs
+++ b/generic-ec/src/serde.rs
@@ -74,6 +74,7 @@
 //! # Ok(()) }
 //! ```
 
+#![cfg(feature = "serde")]
 use core::{convert::TryInto, fmt};
 
 use phantom_type::PhantomType;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy", "rust-src"]
+targets = []

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "stable"
 components = ["rustfmt", "clippy", "rust-src"]
-targets = []
+targets = ["wasm32-unknown-unknown"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,0 @@
-[toolchain]
-channel = "stable"
-components = ["rustfmt", "clippy", "rust-src"]
-targets = ["wasm32-unknown-unknown"]

--- a/wasm/nostd/Cargo.toml
+++ b/wasm/nostd/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "nostd-example"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+generic-ec = { path = "../../generic-ec", default-features = false, features = ["udigest", "all-curves"] }
+generic-ec-zkp = { path = "../../generic-ec-zkp", default-features = false, features = ["udigest"] }

--- a/wasm/nostd/Cargo.toml
+++ b/wasm/nostd/Cargo.toml
@@ -6,4 +6,5 @@ publish = false
 
 [dependencies]
 generic-ec = { path = "../../generic-ec", default-features = false, features = ["udigest", "all-curves"] }
+generic-ec-curves = { path = "../../generic-ec-curves", default-features = false }
 generic-ec-zkp = { path = "../../generic-ec-zkp", default-features = false, features = ["udigest"] }

--- a/wasm/nostd/src/lib.rs
+++ b/wasm/nostd/src/lib.rs
@@ -1,0 +1,12 @@
+#![no_std]
+
+use ::core::panic::PanicInfo;
+
+pub use generic_ec::*;
+pub use generic_ec_curves::*;
+pub use generic_ec_zkp::*;
+
+#[panic_handler]
+fn panic(_panic: &PanicInfo<'_>) -> ! {
+    loop {}
+}

--- a/wasm/wasm-example/Cargo.toml
+++ b/wasm/wasm-example/Cargo.toml
@@ -8,9 +8,10 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-generic-ec = { path = "../../generic-ec", features = ["all-curves", "wasm"] }
+generic-ec = { path = "../../generic-ec", features = ["all-curves"] }
 rand_core = "0.6"
 wasm-bindgen = "0.2.84"
+getrandom = { version = "0.2", features = ["js"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.34"

--- a/wasm/wasm-example/Cargo.toml
+++ b/wasm/wasm-example/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 generic-ec = { path = "../../generic-ec", features = ["all-curves"] }
-rand_core = "0.6"
+rand_core = { version = "0.6", features = ["getrandom"] }
 wasm-bindgen = "0.2.84"
 getrandom = { version = "0.2", features = ["js"] }
 


### PR DESCRIPTION
Greetings, I am attempting to utilize genaric-ec (using cggmp21) by compiling it with the no_std feature and running it in wasm (albeit not in the browser). I initially believed that the compilation would be flawless, however, due to the requirement for getrandom (even without the wasm feature), the compilation fails and complains about the absence of the get random implementation.

Before this change, running `cargo b -p generic-ec --no-default-features --target wasm32-unknown-unknown` result in the following error:

```rs
Compiling getrandom v0.2.12
error: the wasm*-unknown-unknown targets are not supported by default, you may need to enable the "js" feature. For more information see: https://docs.rs/getrandom/#webassembly-support
   --> /home/codespace/.cargo/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.12/src/lib.rs:291:9
    |
291 | /         compile_error!("the wasm*-unknown-unknown targets are not supported by \
292 | |                         default, you may need to enable the \"js\" feature. \
293 | |                         For more information see: \
294 | |                         https://docs.rs/getrandom/#webassembly-support");
    | |________________________________________________________________________^

error[E0433]: failed to resolve: use of undeclared crate or module `imp`
   --> /home/codespace/.cargo/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.12/src/lib.rs:347:9
    |
347 |         imp::getrandom_inner(dest)?;
    |         ^^^ use of undeclared crate or module `imp`

For more information about this error, try `rustc --explain E0433`.
```

With this change, running `cargo b -p generic-ec --no-default-features --target wasm32-unknown-unknown` compiles without issues.