### PR TITLE
Expose `generic_ec::as_raw`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 .PHONY: docs docs-open
 
 docs:
-	RUSTDOCFLAGS="--html-in-header katex-header.html --cfg docsrs" cargo +nightly doc --no-deps --all-features
+	RUSTDOCFLAGS="--html-in-header katex-header.html --cfg docsrs" cargo +nightly doc --no-deps --all-features --workspace --exclude nostd-example
 
 docs-open:
-	RUSTDOCFLAGS="--html-in-header katex-header.html --cfg docsrs" cargo +nightly doc --no-deps --all-features --open
+	RUSTDOCFLAGS="--html-in-header katex-header.html --cfg docsrs" cargo +nightly doc --no-deps --all-features --workspace --exclude nostd-example --open
 
 docs-private:
-	RUSTDOCFLAGS="--html-in-header katex-header.html --cfg docsrs" cargo +nightly doc --no-deps --all-features --document-private-items
+	RUSTDOCFLAGS="--html-in-header katex-header.html --cfg docsrs" cargo +nightly doc --no-deps --all-features --workspace --exclude nostd-example --document-private-items
 
 readme:
 	(cd generic-ec; cargo rdme -r ../README.md)

--- a/generic-ec-curves/src/rust_crypto/mod.rs
+++ b/generic-ec-curves/src/rust_crypto/mod.rs
@@ -27,6 +27,26 @@ pub struct RustCryptoCurve<C, X> {
     _ph: PhantomData<fn() -> (C, X)>,
 }
 
+impl<C, X> RustCryptoCurve<C, X>
+where
+    C: CurveArithmetic,
+{
+    /// Constructs a point on the curve
+    pub fn point(point: C::ProjectivePoint) -> RustCryptoPoint<C> {
+        RustCryptoPoint(point)
+    }
+}
+
+impl<C, X> RustCryptoCurve<C, X>
+where
+    C: CurveArithmetic,
+{
+    /// Constructs a point on the curve
+    pub fn scalar(scalar: C::Scalar) -> RustCryptoScalar<C> {
+        RustCryptoScalar(scalar)
+    }
+}
+
 /// secp256k1 curve
 ///
 /// Based on [k256] crate

--- a/generic-ec/src/as_raw.rs
+++ b/generic-ec/src/as_raw.rs
@@ -42,6 +42,7 @@ pub trait TryFromRaw: AsRaw {
     fn ct_try_from_raw(raw: Self::Raw) -> CtOption<Self>;
 }
 
+/// Constructs a point/scalar from its backend library representation when conversion can be done infallibly
 pub trait FromRaw: AsRaw {
     /// Infallibly wraps raw value
     fn from_raw(raw: Self::Raw) -> Self;

--- a/generic-ec/src/lib.rs
+++ b/generic-ec/src/lib.rs
@@ -185,7 +185,7 @@ extern crate alloc;
 pub use generic_ec_core as core;
 
 mod arithmetic;
-mod as_raw;
+pub mod as_raw;
 pub mod coords;
 mod encoded;
 pub mod errors;


### PR DESCRIPTION
This module is useful when doing something that's not exposed by our API but supported by backend EC library