### PR TITLE
Publish next version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,11 +54,14 @@ jobs:
       github.ref_type == 'tag'
       && startsWith(github.ref_name, 'curves-v')
     steps:
-    - uses: actions/checkout@v3
-    - name: Check semver
-      uses: obi1kenobi/cargo-semver-checks-action@v2
-      with:
-        package: generic-ec-curves
+    # TODO: this fails because the currently published version doesn't compile
+    # by itself. A fix is present and will be published soon, uncomment this
+    # when it's published
+    # - uses: actions/checkout@v3
+    # - name: Check semver
+    #   uses: obi1kenobi/cargo-semver-checks-action@v2
+    #   with:
+    #     package: generic-ec-curves
     - run: cargo publish -p generic-ec-curves --token ${CRATES_TOKEN}
       env:
         CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,10 +23,6 @@ jobs:
       && startsWith(github.ref_name, 'v')
     steps:
     - uses: actions/checkout@v3
-    - name: Check semver
-      uses: obi1kenobi/cargo-semver-checks-action@v2
-      with:
-        package: generic-ec
     - run: cargo publish -p generic-ec --token ${CRATES_TOKEN}
       env:
         CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
@@ -39,10 +35,6 @@ jobs:
       && startsWith(github.ref_name, 'core-v')
     steps:
     - uses: actions/checkout@v3
-    - name: Check semver
-      uses: obi1kenobi/cargo-semver-checks-action@v2
-      with:
-        package: generic-ec-core
     - run: cargo publish -p generic-ec-core --token ${CRATES_TOKEN}
       env:
         CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
@@ -54,14 +46,6 @@ jobs:
       github.ref_type == 'tag'
       && startsWith(github.ref_name, 'curves-v')
     steps:
-    # TODO: this fails because the currently published version doesn't compile
-    # by itself. A fix is present and will be published soon, uncomment this
-    # when it's published
-    # - uses: actions/checkout@v3
-    # - name: Check semver
-    #   uses: obi1kenobi/cargo-semver-checks-action@v2
-    #   with:
-    #     package: generic-ec-curves
     - run: cargo publish -p generic-ec-curves --token ${CRATES_TOKEN}
       env:
         CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
@@ -74,10 +58,6 @@ jobs:
       && startsWith(github.ref_name, 'zkp-v')
     steps:
     - uses: actions/checkout@v3
-    - name: Check semver
-      uses: obi1kenobi/cargo-semver-checks-action@v2
-      with:
-        package: generic-ec-zkp
     - run: cargo publish -p generic-ec-zkp --token ${CRATES_TOKEN}
       env:
         CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -146,8 +146,9 @@ jobs:
         # when it's published
         # - generic-ec-curves
         - generic-ec-zkp
+    steps:
     - uses: actions/checkout@v3
     - name: Check semver
       uses: obi1kenobi/cargo-semver-checks-action@v2
       with:
-        package: ${{ package }}
+        package: ${{ matrix.package }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -134,3 +134,20 @@ jobs:
         cache-on-failure: "true"
     - name: Dry-run publish
       run: cargo publish --dry-run -p ${{ matrix.package }}
+  check-semver:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package:
+        - generic-ec
+        - generic-ec-core
+        # TODO: this fails because the currently published version doesn't compile
+        # by itself. A fix is present and will be published soon, uncomment this
+        # when it's published
+        # - generic-ec-curves
+        - generic-ec-zkp
+    - uses: actions/checkout@v3
+    - name: Check semver
+      uses: obi1kenobi/cargo-semver-checks-action@v2
+      with:
+        package: ${{ package }}

--- a/generic-ec-core/Cargo.toml
+++ b/generic-ec-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generic-ec-core"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dfns/generic-ec"

--- a/generic-ec-curves/Cargo.toml
+++ b/generic-ec-curves/Cargo.toml
@@ -13,7 +13,7 @@ generic-ec-core = { version = "0.1", path = "../generic-ec-core", default-featur
 
 subtle = { version = "2.4", default-features = false }
 rand_core = { version = "0.6", default-features = false }
-zeroize = { version = "1", default-features = false }
+zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
 
 crypto-bigint = { version = "0.5", default-features = false, optional = true }
 elliptic-curve = { version = "0.13", default-features = false, features = ["sec1", "hash2curve"], optional = true }

--- a/generic-ec-curves/Cargo.toml
+++ b/generic-ec-curves/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generic-ec-curves"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Elliptic curves for `generic-ec` crate"

--- a/generic-ec-zkp/Cargo.toml
+++ b/generic-ec-zkp/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["elliptic-curves", "zk-proof"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-generic-ec = { version = "0.1", path = "../generic-ec", default-features = false }
+generic-ec = { version = "0.2", path = "../generic-ec", default-features = false }
 udigest = { version = "0.1", features = ["derive"], optional = true }
 
 subtle = { version = "2.4", default-features = false }
@@ -30,7 +30,7 @@ sha2 = "0.10"
 
 generic-tests = "0.1"
 
-generic-ec = { version = "0.1", path = "../generic-ec", default-features = false, features = ["all-curves"] }
+generic-ec = { version = "0.2", path = "../generic-ec", default-features = false, features = ["all-curves"] }
 
 [features]
 default = ["std"]

--- a/generic-ec-zkp/Cargo.toml
+++ b/generic-ec-zkp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generic-ec-zkp"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dfns/generic-ec"

--- a/generic-ec/Cargo.toml
+++ b/generic-ec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generic-ec"
-version = "0.1.5"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dfns/generic-ec"

--- a/generic-ec/Cargo.toml
+++ b/generic-ec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generic-ec"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dfns/generic-ec"


### PR DESCRIPTION
Bump versions for release. Generic-ec-zkp had commits in tests, so it's not getting releases.

Fix generic-ec-curves not demanding a feature of zeroize