### PR TITLE
Fix `serde` module not being available without `serde` feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -141,14 +141,15 @@ jobs:
         package:
         - generic-ec
         - generic-ec-core
-        # TODO: this fails because the currently published version doesn't compile
-        # by itself. A fix is present and will be published soon, uncomment this
-        # when it's published
-        # - generic-ec-curves
+        - generic-ec-curves
         - generic-ec-zkp
+        feature-group:
+        - all-features
+        - only-explicit-features
     steps:
     - uses: actions/checkout@v3
     - name: Check semver
       uses: obi1kenobi/cargo-semver-checks-action@v2
       with:
         package: ${{ matrix.package }}
+        feature-group: ${{ matrix.feature-group }}

--- a/generic-ec/CHANGELOG.md
+++ b/generic-ec/CHANGELOG.md
@@ -1,0 +1,8 @@
+## v0.2.1
+* Make `generic_ec::serde` module always available even when `serde` feature is disabled [#25]
+
+[#25]: https://github.com/dfns/generic-ec/pull/25
+
+## v0.2.0
+
+All changes prior to this version weren't documented

--- a/generic-ec/Cargo.toml
+++ b/generic-ec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generic-ec"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dfns/generic-ec"

--- a/generic-ec/src/serde.rs
+++ b/generic-ec/src/serde.rs
@@ -74,9 +74,6 @@
 //! # Ok(()) }
 //! ```
 
-#![cfg(feature = "serde")]
-use core::{convert::TryInto, fmt};
-
 use phantom_type::PhantomType;
 
 use crate::core::Curve;
@@ -224,6 +221,7 @@ impl<'de, E: Curve> serde_with::DeserializeAs<'de, crate::SecretScalar<E>> for C
     }
 }
 
+#[cfg(feature = "serde")]
 impl<T> serde_with::SerializeAs<crate::NonZero<T>> for Compact
 where
     Compact: serde_with::SerializeAs<T>,
@@ -236,6 +234,7 @@ where
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de, T> serde_with::DeserializeAs<'de, crate::NonZero<T>> for Compact
 where
     Compact: serde_with::DeserializeAs<'de, T>,
@@ -314,7 +313,7 @@ impl<'de, E: Curve> serde::Deserialize<'de> for CurveName<E> {
         pub struct CurveNameVisitor<E: Curve>(PhantomType<E>);
         impl<'de, E: Curve> serde::de::Visitor<'de> for CurveNameVisitor<E> {
             type Value = CurveName<E>;
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(f, "curve {name}", name = E::CURVE_NAME)
             }
             fn visit_str<Error>(self, v: &str) -> Result<Self::Value, Error>


### PR DESCRIPTION
#17 accidentally removed `serde` module from crate API when `serde` feature is turned off. However, we do need that `generic_ec::serde::CurveName` is always available regardless of the features.