### PR TITLE
Fix no_std support after updating to latest udigest

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -128,22 +128,6 @@ jobs:
     - name: Build on wasm32-unknown-unknown (no_std)
       run:
         (cd wasm/nostd && cargo build -p nostd-example --target wasm32-unknown-unknown)
-  check-publish:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        package:
-        - generic-ec
-        - generic-ec-core
-        - generic-ec-curves
-        - generic-ec-zkp
-    steps:
-    - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v2
-      with:
-        cache-on-failure: "true"
-    - name: Dry-run publish
-      run: cargo publish --dry-run -p ${{ matrix.package }}
   check-semver:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_NET_GIT_FETCH_WITH_CLI: true
+  RUSTFLAGS: -D warnings
 
 jobs:
   check-nostd:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,40 @@ exclude = [
   "wasm/nostd",
 ]
 
+[workspace.dependencies]
+generic-array = "0.14"
+
+hex = { version = "0.4", default-features = false }
+
+rand = "0.8"
+rand_core = { version = "0.6", default-features = false }
+
+serde = { version = "1", default-features = false }
+serde_json = "1"
+serde_with = { version = "2", default-features = false }
+
+sha2 = { version = "0.10", default-features = false }
+
+subtle = { version = "2.4", default-features = false }
+
+udigest = { version = "0.2.0", default-features = false }
+
+zeroize = { version = "1", default-features = false }
+
+criterion = "0.5"
+generic-tests = "0.1"
+serde_test = "1"
+rand_dev = "0.1"
+
+[workspace.dependencies.curve25519]
+package = "curve25519-dalek"
+version = "4"
+default-features = false
+
+[patch.crates-io.udigest]
+git = "https://github.com/dfns/udigest"
+branch = "udigest_as"
+
+[patch.crates-io.udigest-derive]
+git = "https://github.com/dfns/udigest"
+branch = "udigest_as"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,11 +41,3 @@ rand_dev = "0.1"
 package = "curve25519-dalek"
 version = "4"
 default-features = false
-
-[patch.crates-io.udigest]
-git = "https://github.com/dfns/udigest"
-branch = "udigest_as"
-
-[patch.crates-io.udigest-derive]
-git = "https://github.com/dfns/udigest"
-branch = "udigest_as"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ sha2 = { version = "0.10", default-features = false }
 
 subtle = { version = "2.4", default-features = false }
 
-udigest = { version = "0.2.0", default-features = false }
+udigest = { version = "0.2.1", default-features = false }
 
 zeroize = { version = "1", default-features = false }
 

--- a/generic-ec-core/Cargo.toml
+++ b/generic-ec-core/Cargo.toml
@@ -9,11 +9,11 @@ description = "Core traits of `generic-ec` crate"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-generic-array = "0.14"
-subtle = { version = "2.4", default-features = false }
-rand_core = { version = "0.6", default-features = false }
-zeroize = { version = "1", default-features = false }
-serde = { version = "1", default-features = false, features = ["derive"], optional = true }
+generic-array.workspace = true
+subtle.workspace = true
+rand_core.workspace = true
+zeroize.workspace = true
+serde = { workspace = true, features = ["derive"], optional = true }
 
 [features]
 default = []

--- a/generic-ec-curves/Cargo.toml
+++ b/generic-ec-curves/Cargo.toml
@@ -11,30 +11,28 @@ repository = "https://github.com/dfns/generic-ec"
 [dependencies]
 generic-ec-core = { version = "0.2", path = "../generic-ec-core", default-features = false }
 
-subtle = { version = "2.4", default-features = false }
-rand_core = { version = "0.6", default-features = false }
-zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
+subtle.workspace = true
+rand_core.workspace = true
+zeroize = { workspace = true, features = ["zeroize_derive"] }
 
 elliptic-curve = { version = "0.13", default-features = false, features = ["sec1", "hash2curve"], optional = true }
 k256 = { version = "0.13", optional = true, default-features = false, features = ["hash2curve"] }
 p256 = { version = "0.13", optional = true, default-features = false, features = ["hash2curve"] }
-sha2 = { version = "0.10", default-features = false, optional = true }
+sha2 = { workspace = true, optional = true }
 stark-curve = { version = "0.1", default-features = false, optional = true }
 
 group = { version = "0.13", default-features = false, optional = true }
 
 [dependencies.curve25519]
-package = "curve25519-dalek"
-version = "4"
-default-features = false
+workspace = true
 features = ["group", "zeroize", "rand_core", "precomputed-tables"]
 optional = true
 
 [dev-dependencies]
-rand = "0.8"
-rand_dev = "0.1"
+rand.workspace = true
+rand_dev.workspace = true
 
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { workspace = true, features = ["html_reports"] }
 
 [features]
 default = []

--- a/generic-ec-zkp/CHANGELOG.md
+++ b/generic-ec-zkp/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.4.1
+* Fix `no_std` support [#43]
+
+[#43]: https://github.com/dfns/generic-ec/pull/43
+
 ## v0.4.0
 * Update `generic-ec` dep to v0.4 [#40]
 * Update `udigest` dep to v0.2 [#40]

--- a/generic-ec-zkp/Cargo.toml
+++ b/generic-ec-zkp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generic-ec-zkp"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dfns/generic-ec"

--- a/generic-ec-zkp/Cargo.toml
+++ b/generic-ec-zkp/Cargo.toml
@@ -13,24 +13,24 @@ keywords = ["elliptic-curves", "zk-proof"]
 
 [dependencies]
 generic-ec = { version = "0.4.0", path = "../generic-ec", default-features = false }
-udigest = { version = "0.2.0", features = ["derive"], optional = true }
+udigest = { workspace = true, features = ["derive"], optional = true }
 
-subtle = { version = "2.4", default-features = false }
-rand_core = { version = "0.6", default-features = false }
+subtle.workspace = true
+rand_core.workspace = true
 
-serde = { version = "1", default-features = false, features = ["derive"], optional = true }
+serde = { workspace = true, features = ["derive"], optional = true }
 
 # We don't depend on this crates directly, but need to specify features to make it compile
-generic-array = "0.14"
+generic-array.workspace = true
 
 [dev-dependencies]
-rand = "0.8"
-rand_dev = "0.1"
-sha2 = "0.10"
+rand.workspace = true
+rand_dev.workspace = true
+sha2.workspace = true
 
-generic-tests = "0.1"
+generic-tests.workspace = true
 
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { workspace = true, features = ["html_reports"] }
 
 generic-ec = { version = "0.4.0", path = "../generic-ec", default-features = false, features = ["all-curves"] }
 

--- a/generic-ec/CHANGELOG.md
+++ b/generic-ec/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.4.1
+* Fix `no_std` support [#43]
+
+[#43]: https://github.com/dfns/generic-ec/pull/43
+
 ## v0.4.0
 * Update `udigest` to v0.2 [#40]
 * Add hash to scalar primitive [#40]

--- a/generic-ec/Cargo.toml
+++ b/generic-ec/Cargo.toml
@@ -15,38 +15,38 @@ keywords = ["elliptic-curves"]
 [dependencies]
 generic-ec-core = { version = "0.2", path = "../generic-ec-core" }
 generic-ec-curves = { version = "0.2", path = "../generic-ec-curves", optional = true }
-udigest = { version = "0.2.0", features = ["derive"], optional = true }
+udigest = { workspace = true, features = ["derive"], optional = true }
 
-subtle = { version = "2.4", default-features = false }
-rand_core = { version = "0.6", default-features = false }
-zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
+subtle.workspace = true
+rand_core.workspace = true
+zeroize = { workspace = true, features = ["zeroize_derive"] }
 
-serde = { version = "1", features = ["derive"], default-features = false, optional = true }
-serde_with = { version = "2", features = ["macros"], default-features = false, optional = true }
-hex = { version = "0.4", default-features = false, optional = true }
+serde = { workspace = true, features = ["derive"], optional = true }
+serde_with = { workspace = true, features = ["macros"], optional = true }
+hex = { workspace = true, optional = true }
 
 phantom-type = { version = "0.4", default-features = false }
 
 digest = { version = "0.10", default-features = false, optional = true }
-rand_hash = { version = "0.1.0", optional = true }
+rand_hash = { version = "0.1", optional = true }
 
 # We use this dependency when both `curve-ed25519` and `alloc` features are enabled,
 # to provide `generic_ec::multiscalar::Dalek`
-curve25519-dalek = { version = "4", default-features = false, optional = true }
+curve25519 = { workspace = true, optional = true }
 
 [dev-dependencies]
-rand = "0.8"
-rand_dev = "0.1"
-sha2 = "0.10"
-serde_json = "1"
-serde_test = "1"
+rand.workspace = true
+rand_dev.workspace = true
+sha2.workspace = true
+serde_json.workspace = true
+serde_test.workspace = true
 
-generic-tests = "0.1"
+generic-tests.workspace = true
 
 [features]
 default = ["std", "serde"]
 std = ["alloc"]
-alloc = ["hex/alloc", "curve25519-dalek?/alloc"]
+alloc = ["hex/alloc", "curve25519?/alloc"]
 serde = ["dep:serde", "generic-ec-core/serde", "hex", "serde_with"]
 udigest = ["dep:udigest"]
 
@@ -54,7 +54,7 @@ curves = ["generic-ec-curves"]
 curve-secp256k1 = ["curves", "generic-ec-curves/secp256k1"]
 curve-secp256r1 = ["curves", "generic-ec-curves/secp256r1"]
 curve-stark = ["curves", "generic-ec-curves/stark"]
-curve-ed25519 = ["curves", "generic-ec-curves/ed25519", "curve25519-dalek"]
+curve-ed25519 = ["curves", "generic-ec-curves/ed25519", "curve25519"]
 all-curves = ["curve-secp256k1", "curve-secp256r1", "curve-stark", "curve-ed25519"]
 
 hash-to-scalar = ["dep:rand_hash", "dep:digest", "udigest"]

--- a/generic-ec/Cargo.toml
+++ b/generic-ec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generic-ec"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dfns/generic-ec"

--- a/generic-ec/src/as_raw.rs
+++ b/generic-ec/src/as_raw.rs
@@ -9,13 +9,6 @@
 
 use subtle::CtOption;
 
-mod sealed {
-    pub trait Sealed {}
-    impl<E: crate::Curve> Sealed for crate::Point<E> {}
-    impl<E: crate::Curve> Sealed for crate::Scalar<E> {}
-    impl<E: crate::Curve> Sealed for crate::EncodedScalar<E> {}
-}
-
 /// Accesses backend library representation of the point/scalar
 pub trait AsRaw
 where

--- a/generic-ec/src/lib.rs
+++ b/generic-ec/src/lib.rs
@@ -206,7 +206,7 @@ mod _unused_deps {
     // dependency tree as `curve-ed25519` feature is enabled, it's just not
     // used directly
     #[cfg(all(feature = "curve-ed25519", not(feature = "alloc")))]
-    use curve25519_dalek as _;
+    use curve25519 as _;
 }
 
 /// Common traits for points and scalars

--- a/generic-ec/src/multiscalar.rs
+++ b/generic-ec/src/multiscalar.rs
@@ -131,7 +131,7 @@ impl MultiscalarMul<crate::curves::Ed25519> for Dalek {
     {
         use alloc::vec::Vec;
 
-        use curve25519_dalek::traits::VartimeMultiscalarMul;
+        use curve25519::traits::VartimeMultiscalarMul;
         use generic_ec_core::{OnCurve, SmallFactor};
 
         use crate::as_raw::AsRaw;
@@ -140,7 +140,7 @@ impl MultiscalarMul<crate::curves::Ed25519> for Dalek {
         let scalars = scalar_points.iter().map(|(s, _)| &s.as_ref().as_raw().0);
         let points = scalar_points.iter().map(|(_, p)| &p.as_ref().as_raw().0);
 
-        let result = curve25519_dalek::EdwardsPoint::vartime_multiscalar_mul(scalars, points);
+        let result = curve25519::EdwardsPoint::vartime_multiscalar_mul(scalars, points);
         let result = generic_ec_curves::ed25519::Point(result);
 
         // Resulting point must be valid

--- a/generic-ec/src/multiscalar.rs
+++ b/generic-ec/src/multiscalar.rs
@@ -109,7 +109,7 @@ impl<E: Curve> MultiscalarMul<E> for Naive {
 
 /// Multiscalar implementation for [`Ed25519`] curve
 ///
-/// [`curve25519_dalek`] library provides multiscalar multiplication algorithm which only
+/// [`curve25519_dalek`](curve25519) library provides multiscalar multiplication algorithm which only
 /// works with [`Ed25519`] curve. Due to the fact that it's specifically instantiated for
 /// the only one curve, this implementation is more efficient than generic [`struct@Default`]
 /// or [`Straus`].

--- a/generic-ec/src/multiscalar/straus.rs
+++ b/generic-ec/src/multiscalar/straus.rs
@@ -63,7 +63,7 @@ use crate::{Curve, Point, Scalar};
 /// $$
 ///
 /// ## Credits
-/// Algorithm was adopted from [`curve25519_dalek`] crate, with the modification that
+/// Algorithm was adopted from [`curve25519_dalek`](curve25519) crate, with the modification that
 /// it would work with any curve, not only with ed25519. You can find original implementation
 /// [here](https://github.com/dalek-cryptography/curve25519-dalek/blob/1efe6a93b176c4389b78e81e52b2cf85d728aac6/curve25519-dalek/src/backend/serial/scalar_mul/straus.rs#L147-L201).
 pub struct Straus;

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -14,18 +14,18 @@ anyhow = "1"
 regex = "1.10"
 tabled = { version = "0.15", default-features = false, features = ["std"] }
 
-serde = { version = "1", features = ["derive"] }
-serde_with = "2"
-serde_test = "1"
-serde_json = "1"
-hex = "0.4"
+serde = { workspace = true, features = ["derive"] }
+serde_with.workspace = true
+serde_test.workspace = true
+serde_json.workspace = true
+hex.workspace = true
 
 [dev-dependencies]
-generic-tests = "0.1"
-rand_dev = "0.1"
-rand = "0.8"
+generic-tests.workspace = true
+rand_dev.workspace = true
+rand.workspace = true
 
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { workspace = true, features = ["html_reports"] }
 
 [features]
 default = ["generic-ec/std"]

--- a/wasm/nostd/Cargo.toml
+++ b/wasm/nostd/Cargo.toml
@@ -8,3 +8,11 @@ publish = false
 generic-ec = { path = "../../generic-ec", default-features = false, features = ["udigest", "all-curves"] }
 generic-ec-curves = { path = "../../generic-ec-curves", default-features = false }
 generic-ec-zkp = { path = "../../generic-ec-zkp", default-features = false, features = ["udigest"] }
+
+[patch.crates-io.udigest]
+git = "https://github.com/dfns/udigest"
+branch = "udigest_as"
+
+[patch.crates-io.udigest-derive]
+git = "https://github.com/dfns/udigest"
+branch = "udigest_as"

--- a/wasm/nostd/Cargo.toml
+++ b/wasm/nostd/Cargo.toml
@@ -8,11 +8,3 @@ publish = false
 generic-ec = { path = "../../generic-ec", default-features = false, features = ["udigest", "all-curves"] }
 generic-ec-curves = { path = "../../generic-ec-curves", default-features = false }
 generic-ec-zkp = { path = "../../generic-ec-zkp", default-features = false, features = ["udigest"] }
-
-[patch.crates-io.udigest]
-git = "https://github.com/dfns/udigest"
-branch = "udigest_as"
-
-[patch.crates-io.udigest-derive]
-git = "https://github.com/dfns/udigest"
-branch = "udigest_as"

--- a/wasm/wasm-example/Cargo.toml
+++ b/wasm/wasm-example/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 generic-ec = { path = "../../generic-ec", features = ["all-curves"] }
-rand_core = { version = "0.6", features = ["getrandom"] }
+rand_core = { workspace = true, features = ["getrandom"] }
 wasm-bindgen = "0.2.84"
 getrandom = { version = "0.2", features = ["js"] }
 


### PR DESCRIPTION
generic-ec is dependent on `std` feature of `udigest` which breaks no_std support. It used to do no harm as `std` feature in `udigest` was no-op, however, in the latest update it's no longer no-op.

PR removes dependency on `std` feature of `udigest`

Clippy still produces false-positives in the tests

Changelog check also seem to produce a false-positive