### PR TITLE
Constant-time scalar sampling & hash-to-scalar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,12 +704,27 @@ dependencies = [
 
 [[package]]
 name = "generic-ec"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de1099ac0b4d87261d67ff5d4ed400af617a1da40b58908d759b9cf5fd8ed27"
+dependencies = [
+ "curve25519-dalek",
+ "generic-ec-core 0.2.3",
+ "generic-ec-curves 0.2.4",
+ "phantom-type",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "generic-ec"
 version = "0.5.0"
 dependencies = [
  "curve25519-dalek",
  "digest",
- "generic-ec-core",
- "generic-ec-curves",
+ "generic-ec-core 0.3.0",
+ "generic-ec-curves 0.3.0",
  "generic-tests",
  "hex",
  "phantom-type",
@@ -729,10 +744,41 @@ dependencies = [
 
 [[package]]
 name = "generic-ec-core"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcba5fdf70cc3ce5805c487f8523b4ceeb32e8ec5237c71ffd93c1ca47a97fee"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "generic-ec-core"
 version = "0.3.0"
 dependencies = [
  "generic-array",
  "serde",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "generic-ec-curves"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7c6d23001a5eb60eec2b785a63d2ca965fdfbaf3314b3b46df047398369e28"
+dependencies = [
+ "curve25519-dalek",
+ "elliptic-curve",
+ "generic-ec-core 0.2.3",
+ "group",
+ "k256",
+ "p256",
+ "rand_core",
+ "sha2",
+ "stark-curve",
  "subtle",
  "zeroize",
 ]
@@ -744,7 +790,7 @@ dependencies = [
  "criterion",
  "curve25519-dalek",
  "elliptic-curve",
- "generic-ec-core",
+ "generic-ec-core 0.3.0",
  "group",
  "k256",
  "p256",
@@ -764,7 +810,8 @@ dependencies = [
  "anyhow",
  "criterion",
  "digest",
- "generic-ec",
+ "generic-ec 0.4.5",
+ "generic-ec 0.5.0",
  "generic-ec-zkp",
  "generic-tests",
  "hex",
@@ -787,7 +834,7 @@ dependencies = [
  "criterion",
  "digest",
  "generic-array",
- "generic-ec",
+ "generic-ec 0.5.0",
  "generic-tests",
  "rand",
  "rand_core",
@@ -1713,7 +1760,7 @@ dependencies = [
 name = "wasm-example"
 version = "0.1.0"
 dependencies = [
- "generic-ec",
+ "generic-ec 0.5.0",
  "getrandom",
  "rand_core",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,7 +732,6 @@ name = "generic-ec-core"
 version = "0.2.3"
 dependencies = [
  "generic-array",
- "rand_core",
  "serde",
  "subtle",
  "zeroize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "generic-ec"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "curve25519-dalek",
  "digest",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "generic-ec-core"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "generic-array",
  "serde",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "generic-ec-curves"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "criterion",
  "curve25519-dalek",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "generic-ec-zkp"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "criterion",
  "digest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,10 +14,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "aho-corasick"
@@ -51,21 +51,21 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anyhow"
-version = "1.0.81"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "autocfg"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "base16ct"
@@ -81,9 +81,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "block-buffer"
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.4"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytecount"
@@ -108,9 +108,9 @@ checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytemuck"
-version = "1.15.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
+checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 
 [[package]]
 name = "byteorder"
@@ -126,9 +126,12 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "e4730490333d58093109dc02c23174c3f4d490998c3fed3cc8e82d57afedb9cf"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -138,16 +141,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.37"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -179,18 +182,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -198,31 +201,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
-
-[[package]]
-name = "console_error_panic_hook"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
-dependencies = [
- "cfg-if",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "const-cstr"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3d0b5ff30645a68f35ece8cea4556ca14ef8a1651455f789a099a0513532a6"
 
 [[package]]
 name = "const-oid"
@@ -242,15 +229,15 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
-version = "0.22.3"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -272,9 +259,9 @@ dependencies = [
 
 [[package]]
 name = "core-text"
-version = "19.2.0"
+version = "20.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d74ada66e07c1cefa18f8abfba765b486f250de2e4a999e5727fc0dd4b4a25"
+checksum = "c9d2790b5c08465d49f8dc05c8bcae9fea467855947db39b0f8145c091aaced5"
 dependencies = [
  "core-foundation",
  "core-graphics",
@@ -284,18 +271,18 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
@@ -338,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -357,15 +344,15 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-bigint"
@@ -391,16 +378,15 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
  "fiat-crypto",
  "group",
- "platforms",
  "rand_core",
  "rustc_version",
  "subtle",
@@ -415,14 +401,14 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "darling"
-version = "0.20.8"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -430,27 +416,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.8"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.58",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.8"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -474,24 +460,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
+name = "dirs"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "cfg-if",
- "dirs-sys-next",
+ "dirs-sys",
 ]
 
 [[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
+name = "dirs-sys"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
+ "option-ext",
  "redox_users",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -505,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "dwrote"
-version = "0.11.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439a1c2ba5611ad3ed731280541d36d2e9c4ac5e7fb818a27b604bdc5a6aa65b"
+checksum = "70182709525a3632b2ba96b6569225467b18ecb4a77f46d255f713a6bebf05fd"
 dependencies = [
  "lazy_static",
  "libc",
@@ -529,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elliptic-curve"
@@ -557,18 +543,18 @@ version = "3.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bf1fa3f06bbff1ea5b1a9c7b14aa992a39657db60a2759457328d7e058f49ee"
 dependencies = [
- "num-bigint 0.4.4",
+ "num-bigint 0.4.6",
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "fdeflate"
-version = "0.3.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
@@ -603,15 +589,15 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "flate2"
-version = "1.0.28"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -619,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "float-ord"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bad48618fdb549078c333a7a8528acb57af271d0433bdecd523eb620628364e"
+checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
 
 [[package]]
 name = "fnv"
@@ -631,19 +617,19 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "font-kit"
-version = "0.11.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21fe28504d371085fae9ac7a3450f0b289ab71e07c8e57baa3fb68b9e57d6ce5"
+checksum = "b64b34f4efd515f905952d91bc185039863705592c0c53ae6d979805dd154520"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.8.0",
  "byteorder",
  "core-foundation",
  "core-graphics",
  "core-text",
- "dirs-next",
+ "dirs",
  "dwrote",
  "float-ord",
- "freetype",
+ "freetype-sys",
  "lazy_static",
  "libc",
  "log",
@@ -656,34 +642,36 @@ dependencies = [
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
+ "foreign-types-macros",
  "foreign-types-shared",
 ]
 
 [[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
+name = "foreign-types-macros"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
-name = "freetype"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc8599a3078adf8edeb86c71e9f8fa7d88af5ca31e806a867756081f90f5d83"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
- "freetype-sys",
- "libc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
-name = "freetype-sys"
-version = "0.19.0"
+name = "foreign-types-shared"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ee28c39a43d89fbed8b4798fb4ba56722cfd2b5af81f9326c27614ba88ecd5"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
+name = "freetype-sys"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7edc5b9669349acfda99533e9e0bcf26a51862ab43b08ee7745c55d28eb134"
 dependencies = [
  "cc",
  "libc",
@@ -704,27 +692,12 @@ dependencies = [
 
 [[package]]
 name = "generic-ec"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de1099ac0b4d87261d67ff5d4ed400af617a1da40b58908d759b9cf5fd8ed27"
-dependencies = [
- "curve25519-dalek",
- "generic-ec-core 0.2.3",
- "generic-ec-curves 0.2.4",
- "phantom-type",
- "rand_core",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "generic-ec"
 version = "0.5.0"
 dependencies = [
  "curve25519-dalek",
  "digest",
- "generic-ec-core 0.3.0",
- "generic-ec-curves 0.3.0",
+ "generic-ec-core",
+ "generic-ec-curves",
  "generic-tests",
  "hex",
  "phantom-type",
@@ -744,41 +717,11 @@ dependencies = [
 
 [[package]]
 name = "generic-ec-core"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcba5fdf70cc3ce5805c487f8523b4ceeb32e8ec5237c71ffd93c1ca47a97fee"
-dependencies = [
- "generic-array",
- "rand_core",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "generic-ec-core"
 version = "0.3.0"
 dependencies = [
  "generic-array",
- "serde",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "generic-ec-curves"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7c6d23001a5eb60eec2b785a63d2ca965fdfbaf3314b3b46df047398369e28"
-dependencies = [
- "curve25519-dalek",
- "elliptic-curve",
- "generic-ec-core 0.2.3",
- "group",
- "k256",
- "p256",
  "rand_core",
- "sha2",
- "stark-curve",
+ "serde",
  "subtle",
  "zeroize",
 ]
@@ -790,7 +733,7 @@ dependencies = [
  "criterion",
  "curve25519-dalek",
  "elliptic-curve",
- "generic-ec-core 0.3.0",
+ "generic-ec-core",
  "group",
  "k256",
  "p256",
@@ -810,8 +753,7 @@ dependencies = [
  "anyhow",
  "criterion",
  "digest",
- "generic-ec 0.4.5",
- "generic-ec 0.5.0",
+ "generic-ec",
  "generic-ec-zkp",
  "generic-tests",
  "hex",
@@ -834,7 +776,7 @@ dependencies = [
  "criterion",
  "digest",
  "generic-array",
- "generic-ec 0.5.0",
+ "generic-ec",
  "generic-tests",
  "rand",
  "rand_core",
@@ -847,20 +789,20 @@ dependencies = [
 
 [[package]]
 name = "generic-tests"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb39ec0dacc89541b6eced815ab9e97f6b7d44078628abb090c6437763fd050"
+checksum = "d9ff6d6584f4f6fa911d5e07856abf1a48dc5599b3734f2eaea130f2c3baa989"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -892,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eceaaeec696539ddaf7b333340f1af35a5aa87ae3e4f3ead0532f72affab2e"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -902,9 +844,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hex"
@@ -920,9 +862,9 @@ checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.60"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -963,13 +905,13 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.12"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -983,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jpeg-decoder"
@@ -995,18 +937,19 @@ checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "k256"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
  "elliptic-curve",
@@ -1014,24 +957,24 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libloading"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1040,29 +983,39 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.8.0",
  "libc",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "minicov"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27fe9f1cc3c22e1687f9446c2083c4c5fc7f0bcf1c7a86bdbded14985895b4b"
+dependencies = [
+ "cc",
+ "walkdir",
+]
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
- "adler",
+ "adler2",
  "simd-adler32",
 ]
 
@@ -1079,11 +1032,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -1099,24 +1051,30 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "oorandom"
-version = "11.1.3"
+version = "11.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "p256"
@@ -1151,9 +1109,9 @@ dependencies = [
 
 [[package]]
 name = "pathfinder_simd"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebf45976c56919841273f2a0fc684c28437e2f304e264557d9c72be5d5a718be"
+checksum = "5cf07ef4804cfa9aea3b04a7bbdd5a40031dbb6b4f2cbaf2b011666c80c5b4f2"
 dependencies = [
  "rustc_version",
 ]
@@ -1169,21 +1127,15 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
-
-[[package]]
-name = "platforms"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plotters"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
 dependencies = [
  "chrono",
  "font-kit",
@@ -1201,15 +1153,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
 
 [[package]]
 name = "plotters-bitmap"
-version = "0.3.3"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cebbe1f70205299abc69e8b295035bb52a6a70ee35474ad10011f0a4efb8543"
+checksum = "72ce181e3f6bf82d6c1dc569103ca7b1bd964c60ba03d7e6cdfbb3e3eb7f7405"
 dependencies = [
  "gif",
  "image",
@@ -1218,18 +1170,18 @@ dependencies = [
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
 
 [[package]]
 name = "png"
-version = "0.17.13"
+version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e4b0d3d1312775e782c86c91a111aa1f910cbb65e1337f9975b5f9a554b5e1"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
 dependencies = [
  "bitflags 1.3.2",
  "crc32fast",
@@ -1240,9 +1192,12 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "primeorder"
@@ -1255,18 +1210,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1314,9 +1269,9 @@ dependencies = [
 
 [[package]]
 name = "rand_hash"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "257d7a1ad5533c1faca40f34d4a1ead75b414f16611c0ec210b7fd23e440475f"
+checksum = "16bc1dd921383c6564eb0b8252f5b3f6622b84d40c6e35f5e6790e1fd7abb7a9"
 dependencies = [
  "digest",
  "rand_core",
@@ -1345,9 +1300,9 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
@@ -1356,9 +1311,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1368,9 +1323,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1379,24 +1334,30 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.17"
+name = "rustversion"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+
+[[package]]
+name = "ryu"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "same-file"
@@ -1406,12 +1367,6 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "sec1"
@@ -1428,46 +1383,47 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.22"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_test"
-version = "1.0.176"
+version = "1.0.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a2f49ace1498612d14f7e0b8245519584db8299541dfe31a06374a828d620ab"
+checksum = "7f901ee573cab6b3060453d2d5f0bae4e6d628c23c0a962ff9b5f1d7c8d4f1ed"
 dependencies = [
  "serde",
 ]
@@ -1491,7 +1447,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1506,6 +1462,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1513,9 +1475,9 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "stark-curve"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ffed6a893a0438ef248355db18ea1d2c49f6bd38f1f099a709e0d181e41a21"
+checksum = "2ad5e4452423e6bceebf2ecb2c4680f7159a62196e3e6b0ffb824b8d59c3fc90"
 dependencies = [
  "ff",
  "hex-literal",
@@ -1526,15 +1488,15 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1549,9 +1511,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1570,22 +1532,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1600,9 +1562,9 @@ dependencies = [
 
 [[package]]
 name = "ttf-parser"
-version = "0.17.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375812fa44dab6df41c195cd2f7fecb488f6c09fbaafb62807488cefab642bff"
+checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
 
 [[package]]
 name = "typenum"
@@ -1612,9 +1574,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "udigest"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8c862324ffd970533e7fde91b00bf06cd973e2023bfa6c7df5f96a1c959a9d"
+checksum = "81cd61fa9fb78569e9fe34acf0048fd8cb9ebdbacc47af740745487287043ff0"
 dependencies = [
  "digest",
  "udigest-derive",
@@ -1622,32 +1584,32 @@ dependencies = [
 
 [[package]]
 name = "udigest-derive"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6132fb8382b1bdec1cd01062dbe1e88074610e8fe37c2d504043a45f6400108"
+checksum = "603329303137e0d59238ee4d6b9c085eada8e2a9d20666f3abd9dadf8f8543f4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -1667,46 +1629,48 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.98",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.42"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1714,32 +1678,34 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.98",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.42"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9bf62a58e0780af3e852044583deee40983e5886da43a271dd772379987667b"
+checksum = "66c8d5e33ca3b6d9fa3b4676d774c5778031d27a578c2b007f905acf816152c3"
 dependencies = [
- "console_error_panic_hook",
  "js-sys",
- "scoped-tls",
+ "minicov",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test-macro",
@@ -1747,20 +1713,20 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.42"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f89739351a2e03cb94beb799d47fb2cac01759b40ec441f7de39b00cbf7ef0"
+checksum = "17d5042cc5fa009658f9a7333ef24291b1291a25b6382dd68862a7f3b969f69b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "wasm-example"
 version = "0.1.0"
 dependencies = [
- "generic-ec 0.5.0",
+ "generic-ec",
  "getrandom",
  "rand_core",
  "wasm-bindgen",
@@ -1769,9 +1735,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1801,11 +1767,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1820,74 +1786,147 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wio"
@@ -1900,21 +1939,41 @@ dependencies = [
 
 [[package]]
 name = "yeslogic-fontconfig-sys"
-version = "3.2.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2bbd69036d397ebbff671b1b8e4d918610c181c5a16073b96f984a38d08c386"
+checksum = "503a066b4c037c440169d995b869046827dbc71263f6e8f3be6d77d4f3229dbd"
 dependencies = [
- "const-cstr",
  "dlib",
  "once_cell",
  "pkg-config",
 ]
 
 [[package]]
-name = "zeroize"
-version = "1.7.0"
+name = "zerocopy"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 dependencies = [
  "zeroize_derive",
 ]
@@ -1927,5 +1986,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.98",
 ]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ is an elliptic point on secp256k1 curve.
 ## Exposed API
 
 Limited API is exposed: elliptic point arithmetic (points addition, negation, multiplying at scalar), scalar
-arithmetic (addition, multiplication, inverse modulo prime group order), and encode/decode to bytes represenstation.
+arithmetic (addition, multiplication, inverse modulo prime group order), and encode/decode to bytes representation.
 
 Hash to curve, hash to scalar primitives, accessing affine coordinates of points are available for some curves through
 `FromHash` and other traits.

--- a/docs/nonzero_scalar_random.md
+++ b/docs/nonzero_scalar_random.md
@@ -1,0 +1,26 @@
+Generates random non-zero scalar
+
+# Guarantees
+1. Uniform distribution \
+   Output scalar is uniformly distributed (given that provided PRNG outputs uniformly
+   distributed bytes), with possible negligible bias respective to curve target security
+   level
+2. Constant-time \
+   Random generation algorithm does not branch on input randomness, and in particular,
+   it does not use rejection-sampling strategy (might not be the case with negligible
+   probability respective to the curve target security level[^1])
+3. Reproducible \
+   When random generation algorithm is given the same PRNG with the same seed, it always
+   outputs the same scalar on all platforms
+
+If you don't need constant-time/reproducibility properties, you can use [`random_vartime`](
+Self::random_vartime) instead which is typically faster.
+
+[^1]: we use rejection-sampling strategy in case if a zero scalar is generated, however,
+probability of that happening is negligible
+
+# Panics
+Panics if randomness source returned 100 zero scalars in a row. It happens with negligible
+probability, e.g. for secp256k1 curve it's about $2^{-25600}$, which practically means that
+randomness source is broken.
+

--- a/docs/nonzero_scalar_random_vartime.md
+++ b/docs/nonzero_scalar_random_vartime.md
@@ -1,0 +1,16 @@
+Generates random non-zero scalar using variable time algorithm
+
+# Guarantees
+1. Uniform distribution \
+   Output scalar is uniformly distributed (given that provided PRNG outputs uniformly
+   distributed bytes), with possible negligible bias respective to curve target security
+   level
+
+Unlike [`random`](Self::random) method, this one **is not** constant-time nor reproducible, but
+often it's faster.
+
+# Panics
+Panics if randomness source returned 100 zero scalars in a row. It happens with negligible
+probability, e.g. for secp256k1 curve it's about $2^{-25600}$, which practically means that
+randomness source is broken.
+

--- a/generic-ec-core/CHANGELOG.md
+++ b/generic-ec-core/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.3.0
+* Rename `Samplable` trait into `FromUniformBytes` and change it so it
+  accepts a uniform byte array instead of `impl RngCore` [#55]
+
+[#55]: https://github.com/LFDT-Lockness/generic-ec/pull/55
+
 ## v0.2.3
 * Add `NoInvalidPoints` trait [#50]
 

--- a/generic-ec-core/Cargo.toml
+++ b/generic-ec-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generic-ec-core"
-version = "0.2.3"
+version = "0.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/LFDT-Lockness/generic-ec"

--- a/generic-ec-core/Cargo.toml
+++ b/generic-ec-core/Cargo.toml
@@ -12,6 +12,7 @@ description = "Core traits of `generic-ec` crate"
 generic-array.workspace = true
 subtle.workspace = true
 zeroize.workspace = true
+rand_core.workspace = true
 serde = { workspace = true, features = ["derive"], optional = true }
 
 [features]

--- a/generic-ec-core/Cargo.toml
+++ b/generic-ec-core/Cargo.toml
@@ -11,7 +11,6 @@ description = "Core traits of `generic-ec` crate"
 [dependencies]
 generic-array.workspace = true
 subtle.workspace = true
-rand_core.workspace = true
 zeroize.workspace = true
 serde = { workspace = true, features = ["derive"], optional = true }
 

--- a/generic-ec-core/src/lib.rs
+++ b/generic-ec-core/src/lib.rs
@@ -11,7 +11,6 @@ use core::fmt::Debug;
 use core::hash::Hash;
 
 use generic_array::{ArrayLength, GenericArray};
-use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 use zeroize::Zeroize;
 
@@ -128,10 +127,36 @@ pub trait One {
     fn is_one(x: &Self) -> Choice;
 }
 
-/// Type can be uniformely sampled from source of randomness
+/// Type can be uniformly sampled
 pub trait Samplable {
-    /// Uniformely samples a random value of `Self`
-    fn random<R: RngCore>(rng: &mut R) -> Self;
+    /// Byte array that can be converted into instance of `Self` via [`Samplable::from_uniform_bytes`]
+    type Bytes: ByteArray;
+
+    /// Maps uniformly distributed bytes array to uniformly distributed instance of `Self`.
+    ///
+    /// Instead of taking a source of randomness directly, this implementation takes a byte array, that was
+    /// populated from the source of randomness, and outputs a random element.
+    ///
+    /// ## Guarantees
+    /// When `bytes` are uniformly distributed, output distribution must be indistinguishable from uniform,
+    /// respective to the security level of the curve.
+    ///
+    /// ## Implementation details
+    /// This trait is required to be implemented for scalars. It's recommended to take approach described in
+    /// "5. Hashing to Finite Field" of [RFC9380]:
+    ///
+    /// 1. Take a uniform bytestring of `L` bytes, where
+    ///    ```text
+    ///    L = ceil((ceil(log2(q)) + k) / 8)
+    ///    ```
+    ///
+    ///    `q` is prime (sub)group order, and `k` is target security level in bits
+    /// 2. Interpret the bytestring as big-endian/little-endian encoding of the integer, and reduce it modulo `q`
+    ///
+    /// The output is then guaranteed to have a bias at most 2^-k.
+    ///
+    /// [RFC9380]: https://www.rfc-editor.org/rfc/rfc9380.html#name-hashing-to-a-finite-field
+    fn from_uniform_bytes(bytes: Self::Bytes) -> Self;
 }
 
 /// Checks whether the point is on curve

--- a/generic-ec-core/src/lib.rs
+++ b/generic-ec-core/src/lib.rs
@@ -51,6 +51,7 @@ pub trait Curve: Debug + Copy + Eq + Ord + Hash + Default + Sync + Send + 'stati
         + Zero
         + One
         + FromUniformBytes
+        + SamplableVartime
         + Zeroize
         + Copy
         + Eq
@@ -139,7 +140,12 @@ pub trait FromUniformBytes {
     ///
     /// ## Guarantees
     /// When `bytes` are uniformly distributed, output distribution must be indistinguishable from uniform,
-    /// respective to the security level of the curve.
+    /// with bias respective to the security level of the curve, meaning that any instance of the type can
+    /// appear with equal probability.
+    ///
+    /// Implementation is reproducible: the same input `bytes` give the same output on all platforms.
+    ///
+    /// Implementation is constant-time: there's no branching on the input.
     ///
     /// ## Implementation details
     /// This trait is required to be implemented for scalars. It's recommended to take approach described in
@@ -156,7 +162,24 @@ pub trait FromUniformBytes {
     /// The output is then guaranteed to have a bias at most 2^-k.
     ///
     /// [RFC9380]: https://www.rfc-editor.org/rfc/rfc9380.html#name-hashing-to-a-finite-field
-    fn from_uniform_bytes(bytes: Self::Bytes) -> Self;
+    fn from_uniform_bytes(bytes: &Self::Bytes) -> Self;
+}
+
+/// Samples a uniform instance of the type from source of randomness
+pub trait SamplableVartime {
+    /// Samples a uniform instance of the type from source of randomness
+    ///
+    /// ## Guarantees
+    /// If output of provided PRNG is uniform, then the output of this function is uniformly
+    /// distributed (with bias respective to the security level of the curve), meaning that
+    /// any instance of the type can appear with equal probability.
+    ///
+    /// Implementation **is not** reproducible: it may lead to different results on different
+    /// platform and/or instances of the program even if the same `rng` is used with the same
+    /// seed.
+    ///
+    /// Implementation **is not** constant-time: it likely uses reject-sample strategy.
+    fn random_vartime(rng: &mut impl rand_core::RngCore) -> Self;
 }
 
 /// Checks whether the point is on curve

--- a/generic-ec-core/src/lib.rs
+++ b/generic-ec-core/src/lib.rs
@@ -50,7 +50,7 @@ pub trait Curve: Debug + Copy + Eq + Ord + Hash + Default + Sync + Send + 'stati
         + Invertible
         + Zero
         + One
-        + Samplable
+        + FromUniformBytes
         + Zeroize
         + Copy
         + Eq
@@ -127,9 +127,9 @@ pub trait One {
     fn is_one(x: &Self) -> Choice;
 }
 
-/// Type can be uniformly sampled
-pub trait Samplable {
-    /// Byte array that can be converted into instance of `Self` via [`Samplable::from_uniform_bytes`]
+/// Uniform instance of the type can be derived from uniformly distributed byte array
+pub trait FromUniformBytes {
+    /// Byte array that can be converted into instance of `Self` via [`FromUniformBytes::from_uniform_bytes`]
     type Bytes: ByteArray;
 
     /// Maps uniformly distributed bytes array to uniformly distributed instance of `Self`.

--- a/generic-ec-curves/CHANGELOG.md
+++ b/generic-ec-curves/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.3.0
+* Update `generic-ec-core` to v0.3 [#55]
+
+[#55]: https://github.com/LFDT-Lockness/generic-ec/pull/55
+
 ## v0.2.4
 * Implement `NoInvalidPoints` for prime order curves [#50]
 

--- a/generic-ec-curves/Cargo.toml
+++ b/generic-ec-curves/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generic-ec-curves"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Elliptic curves for `generic-ec` crate"
@@ -9,7 +9,7 @@ repository = "https://github.com/LFDT-Lockness/generic-ec"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-generic-ec-core = { version = "0.2.3", path = "../generic-ec-core", default-features = false }
+generic-ec-core = { version = "0.3.0", path = "../generic-ec-core", default-features = false }
 
 subtle.workspace = true
 rand_core.workspace = true

--- a/generic-ec-curves/benches/curves.rs
+++ b/generic-ec-curves/benches/curves.rs
@@ -168,9 +168,9 @@ fn bench_curve<E: Curve>(
 }
 
 fn random_scalar<E: Curve>(rng: &mut impl rand_core::RngCore) -> E::Scalar {
-    let mut bytes = <<E::Scalar as Samplable>::Bytes as ByteArray>::zeroes();
+    let mut bytes = <<E::Scalar as FromUniformBytes>::Bytes as ByteArray>::zeroes();
     rng.fill_bytes(bytes.as_mut());
-    <E::Scalar as Samplable>::from_uniform_bytes(bytes)
+    <E::Scalar as FromUniformBytes>::from_uniform_bytes(bytes)
 }
 
 fn bench_bytes_reduction<E: Curve, const N: usize>(

--- a/generic-ec-curves/benches/curves.rs
+++ b/generic-ec-curves/benches/curves.rs
@@ -170,7 +170,7 @@ fn bench_curve<E: Curve>(
 fn random_scalar<E: Curve>(rng: &mut impl rand_core::RngCore) -> E::Scalar {
     let mut bytes = <<E::Scalar as FromUniformBytes>::Bytes as ByteArray>::zeroes();
     rng.fill_bytes(bytes.as_mut());
-    <E::Scalar as FromUniformBytes>::from_uniform_bytes(bytes)
+    <E::Scalar as FromUniformBytes>::from_uniform_bytes(&bytes)
 }
 
 fn bench_bytes_reduction<E: Curve, const N: usize>(

--- a/generic-ec-curves/benches/curves.rs
+++ b/generic-ec-curves/benches/curves.rs
@@ -38,7 +38,7 @@ fn bench_curve<E: Curve>(
     });
     g.bench_function("[k]P", |b| {
         b.iter_batched(
-            || (E::Scalar::random(rng), random_point::<E>(rng)),
+            || (random_scalar::<E>(rng), random_point::<E>(rng)),
             |(k, p)| E::Scalar::mul(&k, &p),
             criterion::BatchSize::SmallInput,
         );
@@ -81,53 +81,53 @@ fn bench_curve<E: Curve>(
 
     g.bench_function("a+b", |b| {
         b.iter_batched(
-            || (E::Scalar::random(rng), E::Scalar::random(rng)),
+            || (random_scalar::<E>(rng), random_scalar::<E>(rng)),
             |(a, b)| E::Scalar::add(&a, &b),
             criterion::BatchSize::SmallInput,
         );
     });
     g.bench_function("a*b", |b| {
         b.iter_batched(
-            || (E::Scalar::random(rng), E::Scalar::random(rng)),
+            || (random_scalar::<E>(rng), random_scalar::<E>(rng)),
             |(a, b)| E::Scalar::mul(&a, &b),
             criterion::BatchSize::SmallInput,
         );
     });
     g.bench_function("inv(a)", |b| {
         b.iter_batched(
-            || E::Scalar::random(rng),
+            || random_scalar::<E>(rng),
             |a| E::Scalar::invert(&a),
             criterion::BatchSize::SmallInput,
         );
     });
     g.bench_function("RandomScalar", |b| {
-        b.iter(|| E::Scalar::random(rng));
+        b.iter(|| random_scalar::<E>(rng));
     });
 
     g.bench_function("EncodeScalarBE", |b| {
         b.iter_batched(
-            || E::Scalar::random(rng),
+            || random_scalar::<E>(rng),
             |a| a.to_be_bytes(),
             criterion::BatchSize::SmallInput,
         );
     });
     g.bench_function("EncodeScalarLE", |b| {
         b.iter_batched(
-            || E::Scalar::random(rng),
+            || random_scalar::<E>(rng),
             |a| a.to_le_bytes(),
             criterion::BatchSize::SmallInput,
         );
     });
     g.bench_function("DecodeScalarBE", |b| {
         b.iter_batched(
-            || E::Scalar::random(rng).to_be_bytes(),
+            || random_scalar::<E>(rng).to_be_bytes(),
             |bytes| E::Scalar::from_be_bytes_exact(&bytes).unwrap(),
             criterion::BatchSize::SmallInput,
         );
     });
     g.bench_function("DecodeScalarLE", |b| {
         b.iter_batched(
-            || E::Scalar::random(rng).to_le_bytes(),
+            || random_scalar::<E>(rng).to_le_bytes(),
             |bytes| E::Scalar::from_le_bytes_exact(&bytes).unwrap(),
             criterion::BatchSize::SmallInput,
         );
@@ -167,6 +167,12 @@ fn bench_curve<E: Curve>(
     }
 }
 
+fn random_scalar<E: Curve>(rng: &mut impl rand_core::RngCore) -> E::Scalar {
+    let mut bytes = <<E::Scalar as Samplable>::Bytes as ByteArray>::zeroes();
+    rng.fill_bytes(bytes.as_mut());
+    <E::Scalar as Samplable>::from_uniform_bytes(bytes)
+}
+
 fn bench_bytes_reduction<E: Curve, const N: usize>(
     c: &mut criterion::Criterion,
     rng: &mut rand_dev::DevRng,
@@ -199,6 +205,6 @@ fn bench_bytes_reduction<E: Curve, const N: usize>(
 }
 
 fn random_point<E: Curve>(rng: &mut rand_dev::DevRng) -> E::Point {
-    let scalar = E::Scalar::random(rng);
+    let scalar = random_scalar::<E>(rng);
     E::Scalar::mul(&scalar, &CurveGenerator)
 }

--- a/generic-ec-curves/src/ed25519.rs
+++ b/generic-ec-curves/src/ed25519.rs
@@ -221,28 +221,16 @@ impl generic_ec_core::One for Scalar {
 }
 
 impl generic_ec_core::Samplable for Scalar {
-    fn random<R: rand_core::RngCore>(rng: &mut R) -> Self {
-        // Having crypto rng for scalar generation is not a hard requirement,
-        // as in some cases it isn't needed. However, `curve25519` lib asks for
-        // it, so we'll trick it
-        struct FakeCryptoRng<R>(R);
-        impl<R: rand_core::RngCore> rand_core::RngCore for FakeCryptoRng<R> {
-            fn next_u32(&mut self) -> u32 {
-                self.0.next_u32()
-            }
-            fn next_u64(&mut self) -> u64 {
-                self.0.next_u64()
-            }
-            fn fill_bytes(&mut self, dest: &mut [u8]) {
-                self.0.fill_bytes(dest)
-            }
-            fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-                self.0.try_fill_bytes(dest)
-            }
-        }
-        impl<R> rand_core::CryptoRng for FakeCryptoRng<R> {}
+    /// 48 bytes
+    ///
+    /// `L = ceil((ceil(log2(q)) + k) / 8) = ceil((256 + 128) / 8) = 48` bytes are enough to
+    /// guarantee the uniform distribution
+    type Bytes = [u8; 48];
 
-        Self(curve25519::Scalar::random(&mut FakeCryptoRng(rng)))
+    fn from_uniform_bytes(bytes: Self::Bytes) -> Self {
+        let mut bytes_le = [0u8; 64];
+        bytes_le[64 - 48..].copy_from_slice(&bytes);
+        Self(curve25519::Scalar::from_bytes_mod_order_wide(&bytes_le))
     }
 }
 

--- a/generic-ec-curves/src/ed25519.rs
+++ b/generic-ec-curves/src/ed25519.rs
@@ -227,10 +227,36 @@ impl generic_ec_core::FromUniformBytes for Scalar {
     /// guarantee the uniform distribution
     type Bytes = [u8; 48];
 
-    fn from_uniform_bytes(bytes: Self::Bytes) -> Self {
+    fn from_uniform_bytes(bytes: &Self::Bytes) -> Self {
         let mut bytes_le = [0u8; 64];
-        bytes_le[..48].copy_from_slice(&bytes);
+        bytes_le[..48].copy_from_slice(bytes);
         Self(curve25519::Scalar::from_bytes_mod_order_wide(&bytes_le))
+    }
+}
+
+impl generic_ec_core::SamplableVartime for Scalar {
+    fn random_vartime(rng: &mut impl rand_core::RngCore) -> Self {
+        // Having crypto rng for scalar generation is not a hard requirement,
+        // as in some cases it isn't needed. However, `curve25519` lib asks for
+        // it, so we'll trick it
+        struct FakeCryptoRng<R>(R);
+        impl<R: rand_core::RngCore> rand_core::RngCore for FakeCryptoRng<R> {
+            fn next_u32(&mut self) -> u32 {
+                self.0.next_u32()
+            }
+            fn next_u64(&mut self) -> u64 {
+                self.0.next_u64()
+            }
+            fn fill_bytes(&mut self, dest: &mut [u8]) {
+                self.0.fill_bytes(dest)
+            }
+            fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+                self.0.try_fill_bytes(dest)
+            }
+        }
+        impl<R> rand_core::CryptoRng for FakeCryptoRng<R> {}
+
+        Self(curve25519::Scalar::random(&mut FakeCryptoRng(rng)))
     }
 }
 

--- a/generic-ec-curves/src/ed25519.rs
+++ b/generic-ec-curves/src/ed25519.rs
@@ -229,7 +229,7 @@ impl generic_ec_core::FromUniformBytes for Scalar {
 
     fn from_uniform_bytes(bytes: Self::Bytes) -> Self {
         let mut bytes_le = [0u8; 64];
-        bytes_le[64 - 48..].copy_from_slice(&bytes);
+        bytes_le[..48].copy_from_slice(&bytes);
         Self(curve25519::Scalar::from_bytes_mod_order_wide(&bytes_le))
     }
 }

--- a/generic-ec-curves/src/ed25519.rs
+++ b/generic-ec-curves/src/ed25519.rs
@@ -220,7 +220,7 @@ impl generic_ec_core::One for Scalar {
     }
 }
 
-impl generic_ec_core::Samplable for Scalar {
+impl generic_ec_core::FromUniformBytes for Scalar {
     /// 48 bytes
     ///
     /// `L = ceil((ceil(log2(q)) + k) / 8) = ceil((256 + 128) / 8) = 48` bytes are enough to

--- a/generic-ec-curves/src/rust_crypto/mod.rs
+++ b/generic-ec-curves/src/rust_crypto/mod.rs
@@ -14,7 +14,8 @@ use elliptic_curve::ops::Reduce;
 use elliptic_curve::sec1::{FromEncodedPoint, ModulusSize, ToEncodedPoint};
 use elliptic_curve::{CurveArithmetic, FieldBytesSize, ScalarPrimitive};
 use generic_ec_core::{
-    CompressedEncoding, Curve, IntegerEncoding, NoInvalidPoints, Samplable, UncompressedEncoding,
+    CompressedEncoding, Curve, FromUniformBytes, IntegerEncoding, NoInvalidPoints,
+    UncompressedEncoding,
 };
 use subtle::{ConditionallySelectable, ConstantTimeEq};
 use zeroize::{DefaultIsZeroes, Zeroize};
@@ -88,7 +89,7 @@ where
     for<'a> &'a C::ProjectivePoint: Mul<&'a C::Scalar, Output = C::ProjectivePoint>,
     C::Scalar:
         Reduce<C::Uint> + Eq + ConstantTimeEq + ConditionallySelectable + DefaultIsZeroes + Unpin,
-    RustCryptoScalar<C>: scalar::BytesModOrder + Samplable,
+    RustCryptoScalar<C>: scalar::BytesModOrder + FromUniformBytes,
     for<'a> ScalarPrimitive<C>: From<&'a C::Scalar>,
     FieldBytesSize<C>: ModulusSize,
     X: 'static,

--- a/generic-ec-curves/src/rust_crypto/mod.rs
+++ b/generic-ec-curves/src/rust_crypto/mod.rs
@@ -14,7 +14,7 @@ use elliptic_curve::ops::Reduce;
 use elliptic_curve::sec1::{FromEncodedPoint, ModulusSize, ToEncodedPoint};
 use elliptic_curve::{CurveArithmetic, FieldBytesSize, ScalarPrimitive};
 use generic_ec_core::{
-    CompressedEncoding, Curve, IntegerEncoding, NoInvalidPoints, UncompressedEncoding,
+    CompressedEncoding, Curve, IntegerEncoding, NoInvalidPoints, Samplable, UncompressedEncoding,
 };
 use subtle::{ConditionallySelectable, ConstantTimeEq};
 use zeroize::{DefaultIsZeroes, Zeroize};
@@ -88,7 +88,7 @@ where
     for<'a> &'a C::ProjectivePoint: Mul<&'a C::Scalar, Output = C::ProjectivePoint>,
     C::Scalar:
         Reduce<C::Uint> + Eq + ConstantTimeEq + ConditionallySelectable + DefaultIsZeroes + Unpin,
-    RustCryptoScalar<C>: scalar::BytesModOrder,
+    RustCryptoScalar<C>: scalar::BytesModOrder + Samplable,
     for<'a> ScalarPrimitive<C>: From<&'a C::Scalar>,
     FieldBytesSize<C>: ModulusSize,
     X: 'static,

--- a/generic-ec-curves/src/rust_crypto/scalar.rs
+++ b/generic-ec-curves/src/rust_crypto/scalar.rs
@@ -86,6 +86,10 @@ impl<E: CurveArithmetic> One for RustCryptoScalar<E> {
 
 #[cfg(feature = "secp256k1")]
 impl FromUniformBytes for RustCryptoScalar<k256::Secp256k1> {
+    /// 48 bytes
+    ///
+    /// `L = ceil((ceil(log2(q)) + k) / 8) = ceil((256 + 128) / 8) = 48` bytes are enough to
+    /// guarantee the uniform distribution
     type Bytes = [u8; 48];
     fn from_uniform_bytes(bytes: &Self::Bytes) -> Self {
         let mut bytes_be = [0u8; 64];
@@ -95,6 +99,10 @@ impl FromUniformBytes for RustCryptoScalar<k256::Secp256k1> {
 }
 #[cfg(feature = "secp256r1")]
 impl FromUniformBytes for RustCryptoScalar<p256::NistP256> {
+    /// 48 bytes
+    ///
+    /// `L = ceil((ceil(log2(q)) + k) / 8) = ceil((256 + 128) / 8) = 48` bytes are enough to
+    /// guarantee the uniform distribution
     type Bytes = [u8; 48];
     fn from_uniform_bytes(bytes: &Self::Bytes) -> Self {
         BytesModOrder::from_be_bytes_mod_order(bytes)
@@ -102,6 +110,10 @@ impl FromUniformBytes for RustCryptoScalar<p256::NistP256> {
 }
 #[cfg(feature = "stark")]
 impl FromUniformBytes for RustCryptoScalar<stark_curve::StarkCurve> {
+    /// 48 bytes
+    ///
+    /// `L = ceil((ceil(log2(q)) + k) / 8) = ceil((256 + 128) / 8) = 48` bytes are enough to
+    /// guarantee the uniform distribution
     type Bytes = [u8; 48];
     fn from_uniform_bytes(bytes: &Self::Bytes) -> Self {
         BytesModOrder::from_be_bytes_mod_order(bytes)

--- a/generic-ec-curves/src/rust_crypto/scalar.rs
+++ b/generic-ec-curves/src/rust_crypto/scalar.rs
@@ -1,7 +1,7 @@
 use core::ops::Mul;
 
 use elliptic_curve::bigint::{ArrayEncoding, ByteArray, U256, U512};
-use elliptic_curve::{Curve, CurveArithmetic, Field, Group, PrimeField, ScalarPrimitive};
+use elliptic_curve::{Curve, CurveArithmetic, Field, Group, ScalarPrimitive};
 use generic_ec_core::{
     Additive, CurveGenerator, IntegerEncoding, Invertible, Multiplicative, One, Reduce, Samplable,
     Zero,
@@ -84,17 +84,31 @@ impl<E: CurveArithmetic> One for RustCryptoScalar<E> {
     }
 }
 
-impl<E: CurveArithmetic> Samplable for RustCryptoScalar<E> {
-    fn random<R: rand_core::RngCore>(rng: &mut R) -> Self {
-        let mut bytes: <E::Scalar as PrimeField>::Repr = Default::default();
-
-        loop {
-            rng.fill_bytes(bytes.as_mut());
-
-            if let Some(scalar) = <E::Scalar as PrimeField>::from_repr_vartime(bytes.clone()) {
-                break Self(scalar);
-            }
-        }
+#[cfg(feature = "secp256k1")]
+impl Samplable for RustCryptoScalar<k256::Secp256k1> {
+    type Bytes = [u8; 48];
+    fn from_uniform_bytes(bytes: Self::Bytes) -> Self {
+        let mut bytes_be = [0u8; 64];
+        bytes_be[..48].copy_from_slice(&bytes);
+        <Self as Reduce<64>>::from_be_array_mod_order(&bytes_be)
+    }
+}
+#[cfg(feature = "secp256r1")]
+impl Samplable for RustCryptoScalar<p256::NistP256> {
+    type Bytes = [u8; 48];
+    fn from_uniform_bytes(bytes: Self::Bytes) -> Self {
+        let mut bytes_be = [0u8; 64];
+        bytes_be[..48].copy_from_slice(&bytes);
+        BytesModOrder::from_be_bytes_mod_order(&bytes)
+    }
+}
+#[cfg(feature = "stark")]
+impl Samplable for RustCryptoScalar<stark_curve::StarkCurve> {
+    type Bytes = [u8; 48];
+    fn from_uniform_bytes(bytes: Self::Bytes) -> Self {
+        let mut bytes_be = [0u8; 64];
+        bytes_be[..48].copy_from_slice(&bytes);
+        BytesModOrder::from_be_bytes_mod_order(&bytes)
     }
 }
 

--- a/generic-ec-curves/src/rust_crypto/scalar.rs
+++ b/generic-ec-curves/src/rust_crypto/scalar.rs
@@ -4,7 +4,7 @@ use elliptic_curve::bigint::{ArrayEncoding, ByteArray, U256, U512};
 use elliptic_curve::{Curve, CurveArithmetic, Field, Group, ScalarPrimitive};
 use generic_ec_core::{
     Additive, CurveGenerator, FromUniformBytes, IntegerEncoding, Invertible, Multiplicative, One,
-    Reduce, Zero,
+    Reduce, SamplableVartime, Zero,
 };
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 use zeroize::DefaultIsZeroes;
@@ -87,28 +87,39 @@ impl<E: CurveArithmetic> One for RustCryptoScalar<E> {
 #[cfg(feature = "secp256k1")]
 impl FromUniformBytes for RustCryptoScalar<k256::Secp256k1> {
     type Bytes = [u8; 48];
-    fn from_uniform_bytes(bytes: Self::Bytes) -> Self {
+    fn from_uniform_bytes(bytes: &Self::Bytes) -> Self {
         let mut bytes_be = [0u8; 64];
-        bytes_be[64 - 48..].copy_from_slice(&bytes);
+        bytes_be[64 - 48..].copy_from_slice(bytes);
         <Self as Reduce<64>>::from_be_array_mod_order(&bytes_be)
     }
 }
 #[cfg(feature = "secp256r1")]
 impl FromUniformBytes for RustCryptoScalar<p256::NistP256> {
     type Bytes = [u8; 48];
-    fn from_uniform_bytes(bytes: Self::Bytes) -> Self {
-        let mut bytes_be = [0u8; 64];
-        bytes_be[64 - 48..].copy_from_slice(&bytes);
-        BytesModOrder::from_be_bytes_mod_order(&bytes)
+    fn from_uniform_bytes(bytes: &Self::Bytes) -> Self {
+        BytesModOrder::from_be_bytes_mod_order(bytes)
     }
 }
 #[cfg(feature = "stark")]
 impl FromUniformBytes for RustCryptoScalar<stark_curve::StarkCurve> {
     type Bytes = [u8; 48];
-    fn from_uniform_bytes(bytes: Self::Bytes) -> Self {
-        let mut bytes_be = [0u8; 64];
-        bytes_be[64 - 48..].copy_from_slice(&bytes);
-        BytesModOrder::from_be_bytes_mod_order(&bytes)
+    fn from_uniform_bytes(bytes: &Self::Bytes) -> Self {
+        BytesModOrder::from_be_bytes_mod_order(bytes)
+    }
+}
+
+impl<E: CurveArithmetic> SamplableVartime for RustCryptoScalar<E> {
+    fn random_vartime(rng: &mut impl rand_core::RngCore) -> Self {
+        use elliptic_curve::PrimeField;
+
+        let mut bytes: <E::Scalar as PrimeField>::Repr = Default::default();
+        loop {
+            rng.fill_bytes(bytes.as_mut());
+
+            if let Some(scalar) = <E::Scalar as PrimeField>::from_repr_vartime(bytes.clone()) {
+                break Self(scalar);
+            }
+        }
     }
 }
 

--- a/generic-ec-curves/src/rust_crypto/scalar.rs
+++ b/generic-ec-curves/src/rust_crypto/scalar.rs
@@ -89,7 +89,7 @@ impl FromUniformBytes for RustCryptoScalar<k256::Secp256k1> {
     type Bytes = [u8; 48];
     fn from_uniform_bytes(bytes: Self::Bytes) -> Self {
         let mut bytes_be = [0u8; 64];
-        bytes_be[..48].copy_from_slice(&bytes);
+        bytes_be[64 - 48..].copy_from_slice(&bytes);
         <Self as Reduce<64>>::from_be_array_mod_order(&bytes_be)
     }
 }
@@ -98,7 +98,7 @@ impl FromUniformBytes for RustCryptoScalar<p256::NistP256> {
     type Bytes = [u8; 48];
     fn from_uniform_bytes(bytes: Self::Bytes) -> Self {
         let mut bytes_be = [0u8; 64];
-        bytes_be[..48].copy_from_slice(&bytes);
+        bytes_be[64 - 48..].copy_from_slice(&bytes);
         BytesModOrder::from_be_bytes_mod_order(&bytes)
     }
 }
@@ -107,7 +107,7 @@ impl FromUniformBytes for RustCryptoScalar<stark_curve::StarkCurve> {
     type Bytes = [u8; 48];
     fn from_uniform_bytes(bytes: Self::Bytes) -> Self {
         let mut bytes_be = [0u8; 64];
-        bytes_be[..48].copy_from_slice(&bytes);
+        bytes_be[64 - 48..].copy_from_slice(&bytes);
         BytesModOrder::from_be_bytes_mod_order(&bytes)
     }
 }

--- a/generic-ec-curves/src/rust_crypto/scalar.rs
+++ b/generic-ec-curves/src/rust_crypto/scalar.rs
@@ -3,8 +3,8 @@ use core::ops::Mul;
 use elliptic_curve::bigint::{ArrayEncoding, ByteArray, U256, U512};
 use elliptic_curve::{Curve, CurveArithmetic, Field, Group, ScalarPrimitive};
 use generic_ec_core::{
-    Additive, CurveGenerator, IntegerEncoding, Invertible, Multiplicative, One, Reduce, Samplable,
-    Zero,
+    Additive, CurveGenerator, FromUniformBytes, IntegerEncoding, Invertible, Multiplicative, One,
+    Reduce, Zero,
 };
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 use zeroize::DefaultIsZeroes;
@@ -85,7 +85,7 @@ impl<E: CurveArithmetic> One for RustCryptoScalar<E> {
 }
 
 #[cfg(feature = "secp256k1")]
-impl Samplable for RustCryptoScalar<k256::Secp256k1> {
+impl FromUniformBytes for RustCryptoScalar<k256::Secp256k1> {
     type Bytes = [u8; 48];
     fn from_uniform_bytes(bytes: Self::Bytes) -> Self {
         let mut bytes_be = [0u8; 64];
@@ -94,7 +94,7 @@ impl Samplable for RustCryptoScalar<k256::Secp256k1> {
     }
 }
 #[cfg(feature = "secp256r1")]
-impl Samplable for RustCryptoScalar<p256::NistP256> {
+impl FromUniformBytes for RustCryptoScalar<p256::NistP256> {
     type Bytes = [u8; 48];
     fn from_uniform_bytes(bytes: Self::Bytes) -> Self {
         let mut bytes_be = [0u8; 64];
@@ -103,7 +103,7 @@ impl Samplable for RustCryptoScalar<p256::NistP256> {
     }
 }
 #[cfg(feature = "stark")]
-impl Samplable for RustCryptoScalar<stark_curve::StarkCurve> {
+impl FromUniformBytes for RustCryptoScalar<stark_curve::StarkCurve> {
     type Bytes = [u8; 48];
     fn from_uniform_bytes(bytes: Self::Bytes) -> Self {
         let mut bytes_be = [0u8; 64];

--- a/generic-ec-zkp/CHANGELOG.md
+++ b/generic-ec-zkp/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.5.0
+* Update `generic_ec` dep to v0.5 [#55]
+
+[#55]: https://github.com/LFDT-Lockness/generic-ec/pull/55
+
 ## v0.4.4
 * Add `dlog_eq` proof [#54]
 

--- a/generic-ec-zkp/Cargo.toml
+++ b/generic-ec-zkp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generic-ec-zkp"
-version = "0.4.4"
+version = "0.5.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/LFDT-Lockness/generic-ec"
@@ -12,7 +12,7 @@ keywords = ["elliptic-curves", "zk-proof"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-generic-ec = { version = "0.4.0", path = "../generic-ec", default-features = false }
+generic-ec = { version = "0.5.0", path = "../generic-ec", default-features = false }
 digest = { workspace = true, optional = true }
 udigest = { workspace = true, features = ["derive"], optional = true }
 

--- a/generic-ec-zkp/Cargo.toml
+++ b/generic-ec-zkp/Cargo.toml
@@ -33,7 +33,7 @@ generic-tests.workspace = true
 
 criterion = { workspace = true, features = ["html_reports"] }
 
-generic-ec = { version = "0.4.0", path = "../generic-ec", default-features = false, features = ["all-curves"] }
+generic-ec = { version = "0.5.0", path = "../generic-ec", default-features = false, features = ["all-curves"] }
 
 [features]
 default = ["std"]

--- a/generic-ec-zkp/src/polynomial.rs
+++ b/generic-ec-zkp/src/polynomial.rs
@@ -10,7 +10,7 @@ mod requires_alloc {
     use alloc::{vec, vec::Vec};
     use core::{iter, ops};
 
-    use generic_ec::traits::{IsZero, Random, Zero};
+    use generic_ec::traits::{IsZero, Samplable, Zero};
     use rand_core::RngCore;
 
     /// Polynomial $f(x) = \sum_i a_i x^i$ defined as a list of coefficients $[a_0, \dots, a_{\text{degree}}]$
@@ -96,7 +96,7 @@ mod requires_alloc {
         }
     }
 
-    impl<C: Random> Polynomial<C> {
+    impl<C: Samplable> Polynomial<C> {
         /// Samples a random polynomial with specified degree
         pub fn sample(rng: &mut impl RngCore, degree: usize) -> Self {
             Self {

--- a/generic-ec-zkp/src/polynomial.rs
+++ b/generic-ec-zkp/src/polynomial.rs
@@ -10,7 +10,7 @@ mod requires_alloc {
     use alloc::{vec, vec::Vec};
     use core::{iter, ops};
 
-    use generic_ec::traits::{IsZero, Samplable, Zero};
+    use generic_ec::traits::{IsZero, Random, Zero};
     use rand_core::RngCore;
 
     /// Polynomial $f(x) = \sum_i a_i x^i$ defined as a list of coefficients $[a_0, \dots, a_{\text{degree}}]$
@@ -96,7 +96,7 @@ mod requires_alloc {
         }
     }
 
-    impl<C: Samplable> Polynomial<C> {
+    impl<C: Random> Polynomial<C> {
         /// Samples a random polynomial with specified degree
         pub fn sample(rng: &mut impl RngCore, degree: usize) -> Self {
             Self {

--- a/generic-ec/CHANGELOG.md
+++ b/generic-ec/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.5.0
+* Hash to scalar: guarantee reproducibility on all platforms [#55]
+* Use reproducible & constant-time algorithm for random scalar
+  generation [#55]
+* Update `generic-ec-core` & `generic-ec-curves` to v0.3 [#55]
+
+[#55]: https://github.com/LFDT-Lockness/generic-ec/pull/55
+
 ## v0.4.5
 * Add curve-specific aliases (see `generic_ec::curves::{secp256k1, secp256r1, stark, ed25519}::*`) [#52]
 * Implement infallible `FromRaw` for `Point<E>` conversion for prime order curves

--- a/generic-ec/Cargo.toml
+++ b/generic-ec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generic-ec"
-version = "0.4.5"
+version = "0.5.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/LFDT-Lockness/generic-ec"
@@ -13,8 +13,8 @@ keywords = ["elliptic-curves"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-generic-ec-core = { version = "0.2.3", path = "../generic-ec-core" }
-generic-ec-curves = { version = "0.2.4", path = "../generic-ec-curves", optional = true }
+generic-ec-core = { version = "0.3.0", path = "../generic-ec-core" }
+generic-ec-curves = { version = "0.3.0", path = "../generic-ec-curves", optional = true }
 udigest = { workspace = true, features = ["derive"], optional = true }
 
 subtle.workspace = true

--- a/generic-ec/src/lib.rs
+++ b/generic-ec/src/lib.rs
@@ -227,9 +227,30 @@ pub mod traits {
     }
 
     /// Uniformly samples an instance of `Self` from source of randomness
+    ///
+    /// This trait is implemented for scalars in all their variations: `Scalar<E>`,
+    /// `SecretScalar<E>`, `NonZero<Scalar<E>>`, etc.
+    ///
+    /// Under the hood, it uses `NonZero::<Scalar<E>>::{random, random_vartime}`
+    /// methods.
     pub trait Samplable {
         /// Uniformly samples an instance of `Self` from source of randomness
+        /// using constant-time method
+        ///
+        /// Under the hood, it uses [`NonZero::<Scalar<E>>::random()`](
+        /// crate::NonZero::<Scalar<E>>::random()) method,
+        /// therefore it shares the same guarantees and performance drawbacks.
+        /// Refer to its documentation to learn more.
         fn random<R: rand_core::RngCore>(rng: &mut R) -> Self;
+
+        /// Uniformly samples an instance of `Self` from source of randomness
+        /// using vartime method
+        ///
+        /// Under the hood, it uses [`NonZero::<Scalar<E>>::random_vartime()`](
+        /// crate::NonZero::<Scalar<E>>::random_vartime()) method,
+        /// therefore it shares the same guarantees and performance drawbacks.
+        /// Refer to its documentation to learn more.
+        fn random_vartime<R: rand_core::RngCore>(rng: &mut R) -> Self;
     }
 }
 

--- a/generic-ec/src/lib.rs
+++ b/generic-ec/src/lib.rs
@@ -218,12 +218,18 @@ mod _unused_deps {
 /// Common traits for points and scalars
 pub mod traits {
     #[doc(inline)]
-    pub use crate::core::{NoInvalidPoints, One, Reduce, Samplable, Zero};
+    pub use crate::core::{NoInvalidPoints, One, Reduce, Zero};
 
     /// Trait that allows you to check whether value is zero
     pub trait IsZero {
         /// Checks whether `self` is zero
         fn is_zero(&self) -> bool;
+    }
+
+    /// Uniformly samples an instance of `Self` from source of randomness
+    pub trait Samplable {
+        /// Uniformly samples an instance of `Self` from source of randomness
+        fn random<R: rand_core::RngCore>(rng: &mut R) -> Self;
     }
 }
 

--- a/generic-ec/src/lib.rs
+++ b/generic-ec/src/lib.rs
@@ -21,7 +21,7 @@
 //! ## Exposed API
 //!
 //! Limited API is exposed: elliptic point arithmetic (points addition, negation, multiplying at scalar), scalar
-//! arithmetic (addition, multiplication, inverse modulo prime group order), and encode/decode to bytes represenstation.
+//! arithmetic (addition, multiplication, inverse modulo prime group order), and encode/decode to bytes representation.
 //!
 //! Hash to curve, hash to scalar primitives, accessing affine coordinates of points are available for some curves through
 //! `FromHash` and other traits.
@@ -227,7 +227,7 @@ pub mod traits {
     }
 
     /// Uniformly samples an instance of `Self` from source of randomness
-    pub trait Samplable {
+    pub trait Random {
         /// Uniformly samples an instance of `Self` from source of randomness
         fn random<R: rand_core::RngCore>(rng: &mut R) -> Self;
     }

--- a/generic-ec/src/lib.rs
+++ b/generic-ec/src/lib.rs
@@ -227,7 +227,7 @@ pub mod traits {
     }
 
     /// Uniformly samples an instance of `Self` from source of randomness
-    pub trait Random {
+    pub trait Samplable {
         /// Uniformly samples an instance of `Self` from source of randomness
         fn random<R: rand_core::RngCore>(rng: &mut R) -> Self;
     }

--- a/generic-ec/src/non_zero/mod.rs
+++ b/generic-ec/src/non_zero/mod.rs
@@ -8,7 +8,7 @@ use subtle::{ConstantTimeEq, CtOption};
 
 use crate::{
     as_raw::FromRaw,
-    core::Samplable,
+    core::{ByteArray, Samplable},
     errors::{ZeroPoint, ZeroScalar},
     Curve, Point, Scalar, SecretScalar,
 };
@@ -51,10 +51,14 @@ impl<E: Curve> NonZero<Scalar<E>> {
     /// Panics if randomness source returned 100 zero scalars in a row. It happens with
     /// $2^{-25600}$ probability, which practically means that randomness source is broken.
     pub fn random<R: RngCore>(rng: &mut R) -> Self {
-        match iter::repeat_with(|| E::Scalar::random(rng))
-            .take(100)
-            .flat_map(|s| NonZero::from_scalar(Scalar::from_raw(s)))
-            .next()
+        match iter::repeat_with(|| {
+            let mut bytes = <<E::Scalar as Samplable>::Bytes as ByteArray>::zeroes();
+            rng.fill_bytes(bytes.as_mut());
+            <E::Scalar as Samplable>::from_uniform_bytes(bytes)
+        })
+        .take(100)
+        .flat_map(|s| NonZero::from_scalar(Scalar::from_raw(s)))
+        .next()
         {
             Some(s) => s,
             None => panic!("defected source of randomness"),

--- a/generic-ec/src/non_zero/mod.rs
+++ b/generic-ec/src/non_zero/mod.rs
@@ -152,7 +152,7 @@ impl<E: Curve> NonZero<SecretScalar<E>> {
     /// Panics if randomness source returned 100 zero scalars in a row. It happens with
     /// $2^{-25600}$ probability, which practically means that randomness source is broken.
     pub fn random<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
-        <Self as crate::traits::Random>::random(rng)
+        <Self as crate::traits::Samplable>::random(rng)
     }
 
     /// Constructs $S = 1$
@@ -304,13 +304,13 @@ impl<'s, E: Curve> Sum<&'s NonZero<Point<E>>> for Point<E> {
     }
 }
 
-impl<E: Curve> crate::traits::Random for NonZero<Scalar<E>> {
+impl<E: Curve> crate::traits::Samplable for NonZero<Scalar<E>> {
     fn random<R: RngCore>(rng: &mut R) -> Self {
         Self::random(rng)
     }
 }
 
-impl<E: Curve> crate::traits::Random for NonZero<SecretScalar<E>> {
+impl<E: Curve> crate::traits::Samplable for NonZero<SecretScalar<E>> {
     fn random<R: RngCore>(rng: &mut R) -> Self {
         NonZero::<Scalar<E>>::random(rng).into_secret()
     }

--- a/generic-ec/src/non_zero/mod.rs
+++ b/generic-ec/src/non_zero/mod.rs
@@ -41,20 +41,26 @@ impl<E: Curve> NonZero<Point<E>> {
 }
 
 impl<E: Curve> NonZero<Scalar<E>> {
-    /// Generates random non-zero scalar
-    ///
-    /// Algorithm is based on rejection sampling: we sample a scalar, if it's zero try again.
-    /// It may be considered constant-time as zero scalar appears with $2^{-256}$ probability
-    /// which is considered to be negligible.
-    ///
-    /// ## Panics
-    /// Panics if randomness source returned 100 zero scalars in a row. It happens with
-    /// $2^{-25600}$ probability, which practically means that randomness source is broken.
+    #[doc = include_str!("../../docs/nonzero_scalar_random.md")]
     pub fn random<R: RngCore>(rng: &mut R) -> Self {
         match iter::repeat_with(|| {
             let mut bytes = <<E::Scalar as FromUniformBytes>::Bytes as ByteArray>::zeroes();
             rng.fill_bytes(bytes.as_mut());
-            <E::Scalar as FromUniformBytes>::from_uniform_bytes(bytes)
+            <E::Scalar as FromUniformBytes>::from_uniform_bytes(&bytes)
+        })
+        .take(100)
+        .flat_map(|s| NonZero::from_scalar(Scalar::from_raw(s)))
+        .next()
+        {
+            Some(s) => s,
+            None => panic!("defected source of randomness"),
+        }
+    }
+
+    #[doc = include_str!("../../docs/nonzero_scalar_random_vartime.md")]
+    pub fn random_vartime<R: RngCore>(rng: &mut R) -> Self {
+        match iter::repeat_with(|| {
+            <E::Scalar as generic_ec_core::SamplableVartime>::random_vartime(rng)
         })
         .take(100)
         .flat_map(|s| NonZero::from_scalar(Scalar::from_raw(s)))
@@ -142,17 +148,14 @@ impl<E: Curve> NonZero<Scalar<E>> {
 }
 
 impl<E: Curve> NonZero<SecretScalar<E>> {
-    /// Generates random non-zero scalar
-    ///
-    /// Algorithm is based on rejection sampling: we sample a scalar, if it's zero try again.
-    /// It may be considered constant-time as zero scalar appears with $2^{-256}$ probability
-    /// which is considered to be negligible.
-    ///
-    /// ## Panics
-    /// Panics if randomness source returned 100 zero scalars in a row. It happens with
-    /// $2^{-25600}$ probability, which practically means that randomness source is broken.
+    #[doc = include_str!("../../docs/nonzero_scalar_random.md")]
     pub fn random<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
         <Self as crate::traits::Samplable>::random(rng)
+    }
+
+    #[doc = include_str!("../../docs/nonzero_scalar_random_vartime.md")]
+    pub fn random_vartime<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
+        <Self as crate::traits::Samplable>::random_vartime(rng)
     }
 
     /// Constructs $S = 1$
@@ -308,11 +311,19 @@ impl<E: Curve> crate::traits::Samplable for NonZero<Scalar<E>> {
     fn random<R: RngCore>(rng: &mut R) -> Self {
         Self::random(rng)
     }
+
+    fn random_vartime<R: rand_core::RngCore>(rng: &mut R) -> Self {
+        Self::random_vartime(rng)
+    }
 }
 
 impl<E: Curve> crate::traits::Samplable for NonZero<SecretScalar<E>> {
     fn random<R: RngCore>(rng: &mut R) -> Self {
         NonZero::<Scalar<E>>::random(rng).into_secret()
+    }
+
+    fn random_vartime<R: rand_core::RngCore>(rng: &mut R) -> Self {
+        NonZero::<Scalar<E>>::random_vartime(rng).into_secret()
     }
 }
 

--- a/generic-ec/src/non_zero/mod.rs
+++ b/generic-ec/src/non_zero/mod.rs
@@ -8,7 +8,7 @@ use subtle::{ConstantTimeEq, CtOption};
 
 use crate::{
     as_raw::FromRaw,
-    core::{ByteArray, Samplable},
+    core::{ByteArray, FromUniformBytes},
     errors::{ZeroPoint, ZeroScalar},
     Curve, Point, Scalar, SecretScalar,
 };
@@ -52,9 +52,9 @@ impl<E: Curve> NonZero<Scalar<E>> {
     /// $2^{-25600}$ probability, which practically means that randomness source is broken.
     pub fn random<R: RngCore>(rng: &mut R) -> Self {
         match iter::repeat_with(|| {
-            let mut bytes = <<E::Scalar as Samplable>::Bytes as ByteArray>::zeroes();
+            let mut bytes = <<E::Scalar as FromUniformBytes>::Bytes as ByteArray>::zeroes();
             rng.fill_bytes(bytes.as_mut());
-            <E::Scalar as Samplable>::from_uniform_bytes(bytes)
+            <E::Scalar as FromUniformBytes>::from_uniform_bytes(bytes)
         })
         .take(100)
         .flat_map(|s| NonZero::from_scalar(Scalar::from_raw(s)))
@@ -152,7 +152,7 @@ impl<E: Curve> NonZero<SecretScalar<E>> {
     /// Panics if randomness source returned 100 zero scalars in a row. It happens with
     /// $2^{-25600}$ probability, which practically means that randomness source is broken.
     pub fn random<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
-        <Self as crate::traits::Samplable>::random(rng)
+        <Self as crate::traits::Random>::random(rng)
     }
 
     /// Constructs $S = 1$
@@ -304,13 +304,13 @@ impl<'s, E: Curve> Sum<&'s NonZero<Point<E>>> for Point<E> {
     }
 }
 
-impl<E: Curve> crate::traits::Samplable for NonZero<Scalar<E>> {
+impl<E: Curve> crate::traits::Random for NonZero<Scalar<E>> {
     fn random<R: RngCore>(rng: &mut R) -> Self {
         Self::random(rng)
     }
 }
 
-impl<E: Curve> crate::traits::Samplable for NonZero<SecretScalar<E>> {
+impl<E: Curve> crate::traits::Random for NonZero<SecretScalar<E>> {
     fn random<R: RngCore>(rng: &mut R) -> Self {
         NonZero::<Scalar<E>>::random(rng).into_secret()
     }

--- a/generic-ec/src/scalar.rs
+++ b/generic-ec/src/scalar.rs
@@ -319,7 +319,7 @@ impl<E: Curve> crate::traits::One for Scalar<E> {
     }
 }
 
-impl<E: Curve> crate::traits::Random for Scalar<E> {
+impl<E: Curve> crate::traits::Samplable for Scalar<E> {
     fn random<R: RngCore>(rng: &mut R) -> Self {
         Self::random(rng)
     }

--- a/generic-ec/src/scalar.rs
+++ b/generic-ec/src/scalar.rs
@@ -319,7 +319,7 @@ impl<E: Curve> crate::traits::One for Scalar<E> {
     }
 }
 
-impl<E: Curve> crate::traits::Samplable for Scalar<E> {
+impl<E: Curve> crate::traits::Random for Scalar<E> {
     fn random<R: RngCore>(rng: &mut R) -> Self {
         Self::random(rng)
     }

--- a/generic-ec/src/scalar.rs
+++ b/generic-ec/src/scalar.rs
@@ -157,17 +157,20 @@ impl<E: Curve> Scalar<E> {
         Self::from_raw(scalar)
     }
 
-    /// Generates random non-zero scalar
+    /// Samples a uniform scalar from source of randomness using constant-time algorithm
     ///
-    /// Algorithm is based on rejection sampling: we sample a scalar, if it's zero try again.
-    /// It may be considered constant-time as zero scalar appears with $2^{-256}$ probability
-    /// which is considered to be negligible.
-    ///
-    /// ## Panics
-    /// Panics if randomness source returned 100 zero scalars in a row. It happens with
-    /// $2^{-25600}$ probability, which practically means that randomness source is broken.
+    /// Under the hood, it uses [`NonZero::<Scalar<E>>::random()`] method, therefore it shares
+    /// its guarantees and performance. Refer to its documentation to learn more.
     pub fn random<R: RngCore>(rng: &mut R) -> Self {
         NonZero::<Scalar<E>>::random(rng).into()
+    }
+
+    /// Samples a uniform scalar from source of randomness using vartime algorithm
+    ///
+    /// Under the hood, it uses [`NonZero::<Scalar<E>>::random_vartime()`] method, therefore it shares
+    /// its guarantees and performance. Refer to its documentation to learn more.
+    pub fn random_vartime<R: RngCore>(rng: &mut R) -> Self {
+        NonZero::<Scalar<E>>::random_vartime(rng).into()
     }
 
     #[doc = include_str!("../docs/hash_to_scalar.md")]
@@ -322,6 +325,10 @@ impl<E: Curve> crate::traits::One for Scalar<E> {
 impl<E: Curve> crate::traits::Samplable for Scalar<E> {
     fn random<R: RngCore>(rng: &mut R) -> Self {
         Self::random(rng)
+    }
+
+    fn random_vartime<R: rand_core::RngCore>(rng: &mut R) -> Self {
+        Self::random_vartime(rng)
     }
 }
 

--- a/generic-ec/src/secret_scalar/mod.rs
+++ b/generic-ec/src/secret_scalar/mod.rs
@@ -110,7 +110,7 @@ impl<E: Curve> fmt::Debug for SecretScalar<E> {
     }
 }
 
-impl<E: Curve> crate::traits::Samplable for SecretScalar<E> {
+impl<E: Curve> crate::traits::Random for SecretScalar<E> {
     fn random<R: RngCore>(rng: &mut R) -> Self {
         let mut scalar = Scalar::random(rng);
         Self::new(&mut scalar)

--- a/generic-ec/src/secret_scalar/mod.rs
+++ b/generic-ec/src/secret_scalar/mod.rs
@@ -110,7 +110,7 @@ impl<E: Curve> fmt::Debug for SecretScalar<E> {
     }
 }
 
-impl<E: Curve> crate::traits::Random for SecretScalar<E> {
+impl<E: Curve> crate::traits::Samplable for SecretScalar<E> {
     fn random<R: RngCore>(rng: &mut R) -> Self {
         let mut scalar = Scalar::random(rng);
         Self::new(&mut scalar)

--- a/generic-ec/src/secret_scalar/mod.rs
+++ b/generic-ec/src/secret_scalar/mod.rs
@@ -115,4 +115,9 @@ impl<E: Curve> crate::traits::Samplable for SecretScalar<E> {
         let mut scalar = Scalar::random(rng);
         Self::new(&mut scalar)
     }
+
+    fn random_vartime<R: rand_core::RngCore>(rng: &mut R) -> Self {
+        let mut scalar = Scalar::random_vartime(rng);
+        Self::new(&mut scalar)
+    }
 }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -10,6 +10,8 @@ publish = false
 generic-ec = { path = "../generic-ec", default-features = false, features = ["all-curves", "serde"] }
 generic-ec-zkp = { path = "../generic-ec-zkp", default-features = false, features = ["serde", "udigest"] }
 
+generic-ec-v04 = { package = "generic-ec", version = "0.4.5", default-features = false, features = ["all-curves"] }
+
 plotters = "0.3"
 anyhow = "1"
 regex = "1.10"
@@ -35,5 +37,9 @@ default = ["generic-ec/std"]
 
 [[bench]]
 name = "multiscalar"
+harness = false
+
+[[bench]]
+name = "random"
 harness = false
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -10,8 +10,6 @@ publish = false
 generic-ec = { path = "../generic-ec", default-features = false, features = ["all-curves", "serde"] }
 generic-ec-zkp = { path = "../generic-ec-zkp", default-features = false, features = ["serde", "udigest"] }
 
-generic-ec-v04 = { package = "generic-ec", version = "0.4.5", default-features = false, features = ["all-curves"] }
-
 plotters = "0.3"
 anyhow = "1"
 regex = "1.10"

--- a/tests/benches/random.rs
+++ b/tests/benches/random.rs
@@ -1,0 +1,28 @@
+use generic_ec::curves;
+use generic_ec_v04::curves as curves_v04;
+
+criterion::criterion_main!(benches);
+criterion::criterion_group!(benches, random);
+
+fn random(c: &mut criterion::Criterion) {
+    let mut rng = rand_dev::DevRng::new();
+
+    random_for_curve::<curves::Secp256k1, curves_v04::Secp256k1>(c, &mut rng, "secp256k1");
+    random_for_curve::<curves::Secp256r1, curves_v04::Secp256r1>(c, &mut rng, "secp256r1");
+    random_for_curve::<curves::Stark, curves_v04::Stark>(c, &mut rng, "stark");
+    random_for_curve::<curves::Ed25519, curves_v04::Ed25519>(c, &mut rng, "ed25519");
+}
+
+fn random_for_curve<E: generic_ec::Curve, E04: generic_ec_v04::Curve>(
+    c: &mut criterion::Criterion,
+    rng: &mut impl rand::RngCore,
+    curve_name: &str,
+) {
+    let mut g = c.benchmark_group(format!("random/{curve_name}"));
+    g.bench_function("v04", |b| {
+        b.iter(|| generic_ec_v04::Scalar::<E04>::random(rng))
+    });
+    g.bench_function("latest", |b| {
+        b.iter(|| generic_ec::Scalar::<E>::random(rng))
+    });
+}

--- a/tests/benches/random.rs
+++ b/tests/benches/random.rs
@@ -1,5 +1,4 @@
 use generic_ec::curves;
-use generic_ec_v04::curves as curves_v04;
 
 criterion::criterion_main!(benches);
 criterion::criterion_group!(benches, random);
@@ -7,22 +6,22 @@ criterion::criterion_group!(benches, random);
 fn random(c: &mut criterion::Criterion) {
     let mut rng = rand_dev::DevRng::new();
 
-    random_for_curve::<curves::Secp256k1, curves_v04::Secp256k1>(c, &mut rng, "secp256k1");
-    random_for_curve::<curves::Secp256r1, curves_v04::Secp256r1>(c, &mut rng, "secp256r1");
-    random_for_curve::<curves::Stark, curves_v04::Stark>(c, &mut rng, "stark");
-    random_for_curve::<curves::Ed25519, curves_v04::Ed25519>(c, &mut rng, "ed25519");
+    random_for_curve::<curves::Secp256k1>(c, &mut rng, "secp256k1");
+    random_for_curve::<curves::Secp256r1>(c, &mut rng, "secp256r1");
+    random_for_curve::<curves::Stark>(c, &mut rng, "stark");
+    random_for_curve::<curves::Ed25519>(c, &mut rng, "ed25519");
 }
 
-fn random_for_curve<E: generic_ec::Curve, E04: generic_ec_v04::Curve>(
+fn random_for_curve<E: generic_ec::Curve>(
     c: &mut criterion::Criterion,
     rng: &mut impl rand::RngCore,
     curve_name: &str,
 ) {
     let mut g = c.benchmark_group(format!("random/{curve_name}"));
-    g.bench_function("v04", |b| {
-        b.iter(|| generic_ec_v04::Scalar::<E04>::random(rng))
-    });
-    g.bench_function("latest", |b| {
+    g.bench_function("const-time", |b| {
         b.iter(|| generic_ec::Scalar::<E>::random(rng))
+    });
+    g.bench_function("vartime", |b| {
+        b.iter(|| generic_ec::Scalar::<E>::random_vartime(rng))
     });
 }


### PR DESCRIPTION
We currently rely on actual curve implementation (i.e. rust crypto or dalek repos) to provide a function for random scalar generation from source of randomness.

However, in the code, we implicitly rely that random scalar generation is reproducible: we expect that when a reproducible PRNG is provided (such as HashRng) with the same seed, then output scalar is the same on all platforms. It's not guaranteed at all: a library may actually run platform-dependent algorithm for scalar generation, for instance, depending on whether it's x64 or x86 platform.

It is crucial to provide a reproducible `Scalar::random` as it is used in `Scalar::from_hash`, which in return is used in all non-interactive ZK proofs to derive a challenge.

This PR addresses this by implementing random scalar generation within the library. We simply take a sufficiently large bytestring, and reduce it modulo curve prime (sub)group order, in compliance with [RFC9380](https://www.rfc-editor.org/rfc/rfc9380.html#name-hashing-to-a-finite-field).

As a side effect, sampling a scalar is constant-time (which was not the case before)