### PR TITLE
Fix hardcoded scalar size in Straus NAF computation

### DIFF
--- a/generic-ec-curves/src/lib.rs
+++ b/generic-ec-curves/src/lib.rs
@@ -6,7 +6,7 @@
 //! [`generic-ec` crate]: https://docs.rs/generic-ec
 
 #![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(missing_docs)]
 #![no_std]
 

--- a/generic-ec/src/lib.rs
+++ b/generic-ec/src/lib.rs
@@ -184,7 +184,7 @@
 #![cfg_attr(not(test), forbid(unused_crate_dependencies))]
 #![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "std")]
 extern crate std;

--- a/generic-ec/src/multiscalar/straus.rs
+++ b/generic-ec/src/multiscalar/straus.rs
@@ -186,7 +186,7 @@ impl<E: Curve> NafMatrix<E> {
     fn add_scalar(&mut self, scalar: &Scalar<E>) {
         let scalar_bytes = scalar.to_le_bytes();
         let mut x_u64 = vec![0u64; scalar_bytes.len() / 8 + 1];
-        read_le_u64_into(&scalar_bytes, &mut x_u64[0..4]);
+        read_le_u64_into(&scalar_bytes, &mut x_u64[0..scalar_bytes.len() / 8]);
 
         let offset = self.matrix.len();
         debug_assert!(


### PR DESCRIPTION
The `add_scalar` method in `NafMatrix` hardcodes `x_u64[0..4]` when reading scalar bytes, which only works for 32-byte scalars. This panics for curves with different scalar sizes like P-384 or P-521.

Use the actual scalar byte length instead.