### PR TITLE
Add secp384r1 (NIST P-384) curve support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,6 +737,7 @@ dependencies = [
  "group",
  "k256",
  "p256",
+ "p384",
  "rand",
  "rand_core",
  "rand_dev",
@@ -1081,6 +1082,16 @@ name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "elliptic-curve",
+ "primeorder",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
  "elliptic-curve",
  "primeorder",

--- a/README.md
+++ b/README.md
@@ -73,11 +73,13 @@ Crate provides support for following elliptic curves out of box:
 |--------------|--------------------|-------------------|
 | secp256k1    | `curve-secp256k1`  | [RustCrypto/k256] |
 | secp256r1    | `curve-secp256r1`  | [RustCrypto/p256] |
+| secp384r1    | `curve-secp384r1`  | [RustCrypto/p384] |
 | stark-curve  | `curve-stark`      | [Dfns/stark]      |
 | Ed25519      | `curve-ed25519`    | [curve25519-dalek]|
 
 [RustCrypto/k256]: https://github.com/RustCrypto/elliptic-curves/tree/master/k256
 [RustCrypto/p256]: https://github.com/RustCrypto/elliptic-curves/tree/master/p256
+[RustCrypto/p384]: https://github.com/RustCrypto/elliptic-curves/tree/master/p384
 [Dfns/stark]: https://github.com/LFDT-Lockness/stark-curve/
 [curve25519-dalek]: https://docs.rs/curve25519-dalek/
 

--- a/generic-ec-curves/Cargo.toml
+++ b/generic-ec-curves/Cargo.toml
@@ -18,6 +18,7 @@ zeroize = { workspace = true, features = ["zeroize_derive"] }
 elliptic-curve = { version = "0.13", default-features = false, features = ["sec1", "hash2curve"], optional = true }
 k256 = { version = "0.13", optional = true, default-features = false, features = ["hash2curve"] }
 p256 = { version = "0.13", optional = true, default-features = false, features = ["hash2curve"] }
+p384 = { version = "0.13", optional = true, default-features = false, features = ["hash2curve"] }
 sha2 = { workspace = true, optional = true }
 stark-curve = { version = "0.1", default-features = false, optional = true }
 
@@ -39,6 +40,7 @@ default = []
 rust-crypto = ["elliptic-curve"]
 secp256k1 = ["rust-crypto", "k256", "sha2"]
 secp256r1 = ["rust-crypto", "p256", "sha2"]
+secp384r1 = ["rust-crypto", "p384", "sha2"]
 stark = ["rust-crypto", "stark-curve", "sha2"]
 ed25519 = ["dep:curve25519", "dep:group"]
 

--- a/generic-ec-curves/benches/curves.rs
+++ b/generic-ec-curves/benches/curves.rs
@@ -14,6 +14,9 @@ fn bench_curves(c: &mut criterion::Criterion) {
     bench_curve::<generic_ec_curves::Secp256r1>(c, &mut rng, "secp256r1");
     bench_bytes_reduction::<generic_ec_curves::Secp256r1, 32>(c, &mut rng, "secp256r1");
 
+    bench_curve::<generic_ec_curves::Secp384r1>(c, &mut rng, "secp384r1");
+    bench_bytes_reduction::<generic_ec_curves::Secp384r1, 48>(c, &mut rng, "secp384r1");
+
     bench_curve::<generic_ec_curves::Stark>(c, &mut rng, "stark");
     bench_bytes_reduction::<generic_ec_curves::Stark, 32>(c, &mut rng, "stark");
 

--- a/generic-ec-curves/src/lib.rs
+++ b/generic-ec-curves/src/lib.rs
@@ -27,6 +27,9 @@ pub use rust_crypto::Secp256k1;
 #[cfg(feature = "secp256r1")]
 pub use rust_crypto::Secp256r1;
 
+#[cfg(feature = "secp384r1")]
+pub use rust_crypto::Secp384r1;
+
 #[cfg(feature = "stark")]
 pub use rust_crypto::Stark;
 

--- a/generic-ec-curves/src/lib.rs
+++ b/generic-ec-curves/src/lib.rs
@@ -6,7 +6,7 @@
 //! [`generic-ec` crate]: https://docs.rs/generic-ec
 
 #![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(missing_docs)]
 #![no_std]
 

--- a/generic-ec-curves/src/rust_crypto/curve_name.rs
+++ b/generic-ec-curves/src/rust_crypto/curve_name.rs
@@ -14,6 +14,11 @@ impl CurveName for k256::Secp256k1 {
     const CURVE_NAME: &'static str = "secp256k1";
 }
 
+#[cfg(feature = "secp384r1")]
+impl CurveName for p384::NistP384 {
+    const CURVE_NAME: &'static str = "secp384r1";
+}
+
 #[cfg(feature = "stark")]
 impl CurveName for stark_curve::StarkCurve {
     const CURVE_NAME: &'static str = "stark";

--- a/generic-ec-curves/src/rust_crypto/mod.rs
+++ b/generic-ec-curves/src/rust_crypto/mod.rs
@@ -20,7 +20,7 @@ use generic_ec_core::{
 use subtle::{ConditionallySelectable, ConstantTimeEq};
 use zeroize::{DefaultIsZeroes, Zeroize};
 
-#[cfg(any(feature = "secp256k1", feature = "secp256r1", feature = "stark"))]
+#[cfg(any(feature = "secp256k1", feature = "secp256r1", feature = "secp384r1", feature = "stark"))]
 use sha2::Sha256;
 
 pub use self::{curve_name::CurveName, point::RustCryptoPoint, scalar::RustCryptoScalar};
@@ -66,6 +66,12 @@ pub type Secp256k1 = RustCryptoCurve<k256::Secp256k1, ExpandMsgXmd<Sha256>>;
 /// Based on [p256] crate
 #[cfg(feature = "secp256r1")]
 pub type Secp256r1 = RustCryptoCurve<p256::NistP256, ExpandMsgXmd<Sha256>>;
+
+/// secp384r1 curve (NIST P-384)
+///
+/// Based on [p384] crate
+#[cfg(feature = "secp384r1")]
+pub type Secp384r1 = RustCryptoCurve<p384::NistP384, ExpandMsgXmd<sha2::Sha384>>;
 
 /// Stark curve
 ///
@@ -175,6 +181,13 @@ unsafe impl NoInvalidPoints for Secp256r1 {}
 /// Safe because:
 /// - RustCrypto curves are always on curve:
 ///   generic-ec-curves/src/rust_crypto/point.rs:60
+/// - p384 is prime order and so is always torsion-free:
+///   <https://github.com/RustCrypto/elliptic-curves/blob/7a71e403e49fbe92d6b2ae8fe3eabbfdef124975/primeorder/src/projective.rs#L172-L174>
+#[cfg(feature = "secp384r1")]
+unsafe impl NoInvalidPoints for Secp384r1 {}
+/// Safe because:
+/// - RustCrypto curves are always on curve:
+///   generic-ec-curves/src/rust_crypto/point.rs:60
 /// - stark is prime order and so is always torsion-free:
 ///   <https://github.com/RustCrypto/elliptic-curves/blob/7a71e403e49fbe92d6b2ae8fe3eabbfdef124975/primeorder/src/projective.rs#L172-L174>
 #[cfg(feature = "stark")]
@@ -187,7 +200,7 @@ mod tests {
         Curve,
     };
 
-    use super::{Secp256k1, Secp256r1, Stark};
+    use super::{Secp256k1, Secp256r1, Secp384r1, Stark};
 
     /// Asserts that `E` implements `Curve`
     fn _impls_curve<E: Curve>() {}
@@ -196,10 +209,12 @@ mod tests {
     fn _curves_impl_trait() {
         _impls_curve::<Secp256k1>();
         _impls_curve::<Secp256r1>();
+        _impls_curve::<Secp384r1>();
         _impls_curve::<Stark>();
 
         _exposes_affine_coords::<Secp256k1>();
         _exposes_affine_coords::<Secp256r1>();
+        _exposes_affine_coords::<Secp384r1>();
         _exposes_affine_coords::<Stark>();
     }
 }

--- a/generic-ec-curves/src/rust_crypto/mod.rs
+++ b/generic-ec-curves/src/rust_crypto/mod.rs
@@ -20,7 +20,7 @@ use generic_ec_core::{
 use subtle::{ConditionallySelectable, ConstantTimeEq};
 use zeroize::{DefaultIsZeroes, Zeroize};
 
-#[cfg(any(feature = "secp256k1", feature = "secp256r1", feature = "secp384r1", feature = "stark"))]
+#[cfg(any(feature = "secp256k1", feature = "secp256r1", feature = "stark"))]
 use sha2::Sha256;
 
 pub use self::{curve_name::CurveName, point::RustCryptoPoint, scalar::RustCryptoScalar};

--- a/generic-ec-curves/src/rust_crypto/scalar.rs
+++ b/generic-ec-curves/src/rust_crypto/scalar.rs
@@ -1,6 +1,6 @@
 use core::ops::Mul;
 
-use elliptic_curve::bigint::{ArrayEncoding, ByteArray, U256, U512};
+use elliptic_curve::bigint::{ArrayEncoding, ByteArray, U256, U384, U512};
 use elliptic_curve::{Curve, CurveArithmetic, Field, Group, ScalarPrimitive};
 use generic_ec_core::{
     Additive, CurveGenerator, FromUniformBytes, IntegerEncoding, Invertible, Multiplicative, One,
@@ -104,6 +104,17 @@ impl FromUniformBytes for RustCryptoScalar<p256::NistP256> {
     /// `L = ceil((ceil(log2(q)) + k) / 8) = ceil((256 + 128) / 8) = 48` bytes are enough to
     /// guarantee the uniform distribution
     type Bytes = [u8; 48];
+    fn from_uniform_bytes(bytes: &Self::Bytes) -> Self {
+        BytesModOrder::from_be_bytes_mod_order(bytes)
+    }
+}
+#[cfg(feature = "secp384r1")]
+impl FromUniformBytes for RustCryptoScalar<p384::NistP384> {
+    /// 64 bytes
+    ///
+    /// `L = ceil((ceil(log2(q)) + k) / 8) = ceil((384 + 128) / 8) = 64` bytes are enough to
+    /// guarantee the uniform distribution
+    type Bytes = [u8; 64];
     fn from_uniform_bytes(bytes: &Self::Bytes) -> Self {
         BytesModOrder::from_be_bytes_mod_order(bytes)
     }
@@ -265,6 +276,22 @@ where
     }
 }
 
+impl<E: CurveArithmetic + Curve> Reduce<48> for RustCryptoScalar<E>
+where
+    E::Scalar: elliptic_curve::ops::Reduce<U384>,
+{
+    fn from_be_array_mod_order(bytes: &[u8; 48]) -> Self {
+        Self(elliptic_curve::ops::Reduce::<U384>::reduce(
+            U384::from_be_byte_array((*bytes).into()),
+        ))
+    }
+    fn from_le_array_mod_order(bytes: &[u8; 48]) -> Self {
+        Self(elliptic_curve::ops::Reduce::<U384>::reduce(
+            U384::from_le_byte_array((*bytes).into()),
+        ))
+    }
+}
+
 /// Choice of algorithm for computing bytes mod curve order. Efficient algorithm
 /// is different for different curves.
 pub(super) trait BytesModOrder {
@@ -288,6 +315,15 @@ impl BytesModOrder for RustCryptoScalar<p256::NistP256> {
     }
     fn from_le_bytes_mod_order(bytes: &[u8]) -> Self {
         crate::utils::scalar_from_le_bytes_mod_order_reducing_32(bytes, &Self(p256::Scalar::ONE))
+    }
+}
+#[cfg(feature = "secp384r1")]
+impl BytesModOrder for RustCryptoScalar<p384::NistP384> {
+    fn from_be_bytes_mod_order(bytes: &[u8]) -> Self {
+        crate::utils::scalar_from_be_bytes_mod_order_reducing_48(bytes, &Self(p384::Scalar::ONE))
+    }
+    fn from_le_bytes_mod_order(bytes: &[u8]) -> Self {
+        crate::utils::scalar_from_le_bytes_mod_order_reducing_48(bytes, &Self(p384::Scalar::ONE))
     }
 }
 #[cfg(feature = "stark")]

--- a/generic-ec-curves/src/rust_crypto/scalar.rs
+++ b/generic-ec-curves/src/rust_crypto/scalar.rs
@@ -311,31 +311,43 @@ impl BytesModOrder for RustCryptoScalar<k256::Secp256k1> {
 #[cfg(feature = "secp256r1")]
 impl BytesModOrder for RustCryptoScalar<p256::NistP256> {
     fn from_be_bytes_mod_order(bytes: &[u8]) -> Self {
-        crate::utils::scalar_from_be_bytes_mod_order_reducing_32(bytes, &Self(p256::Scalar::ONE))
+        crate::utils::scalar_from_be_bytes_mod_order_reducing::<_, 32>(
+            bytes,
+            &Self(p256::Scalar::ONE),
+        )
     }
     fn from_le_bytes_mod_order(bytes: &[u8]) -> Self {
-        crate::utils::scalar_from_le_bytes_mod_order_reducing_32(bytes, &Self(p256::Scalar::ONE))
+        crate::utils::scalar_from_le_bytes_mod_order_reducing::<_, 32>(
+            bytes,
+            &Self(p256::Scalar::ONE),
+        )
     }
 }
 #[cfg(feature = "secp384r1")]
 impl BytesModOrder for RustCryptoScalar<p384::NistP384> {
     fn from_be_bytes_mod_order(bytes: &[u8]) -> Self {
-        crate::utils::scalar_from_be_bytes_mod_order_reducing_48(bytes, &Self(p384::Scalar::ONE))
+        crate::utils::scalar_from_be_bytes_mod_order_reducing::<_, 48>(
+            bytes,
+            &Self(p384::Scalar::ONE),
+        )
     }
     fn from_le_bytes_mod_order(bytes: &[u8]) -> Self {
-        crate::utils::scalar_from_le_bytes_mod_order_reducing_48(bytes, &Self(p384::Scalar::ONE))
+        crate::utils::scalar_from_le_bytes_mod_order_reducing::<_, 48>(
+            bytes,
+            &Self(p384::Scalar::ONE),
+        )
     }
 }
 #[cfg(feature = "stark")]
 impl BytesModOrder for RustCryptoScalar<stark_curve::StarkCurve> {
     fn from_be_bytes_mod_order(bytes: &[u8]) -> Self {
-        crate::utils::scalar_from_be_bytes_mod_order_reducing_32(
+        crate::utils::scalar_from_be_bytes_mod_order_reducing::<_, 32>(
             bytes,
             &Self(stark_curve::Scalar::ONE),
         )
     }
     fn from_le_bytes_mod_order(bytes: &[u8]) -> Self {
-        crate::utils::scalar_from_le_bytes_mod_order_reducing_32(
+        crate::utils::scalar_from_le_bytes_mod_order_reducing::<_, 32>(
             bytes,
             &Self(stark_curve::Scalar::ONE),
         )

--- a/generic-ec-curves/src/utils.rs
+++ b/generic-ec-curves/src/utils.rs
@@ -133,6 +133,114 @@ where
 /// Interprets `bytes` as little-endian encoding of an integer, takes it modulo curve (prime)
 /// order and returns scalar `S`
 ///
+/// Works with scalars for which only [`Reduce<48>`][Reduce] is defined.
+///
+/// Takes:
+/// * Little-endian `bytes` representation of the integer
+/// * Scalar `one = 1`
+pub fn scalar_from_le_bytes_mod_order_reducing_48<S>(bytes: &[u8], one: &S) -> S
+where
+    S: Default + Copy,
+    S: Reduce<48>,
+    S: generic_ec_core::Additive + generic_ec_core::Multiplicative<S, Output = S>,
+{
+    let len = bytes.len();
+    match len {
+        ..=47 => {
+            let mut padded = [0u8; 48];
+            padded[..len].copy_from_slice(bytes);
+            S::from_le_array_mod_order(&padded)
+        }
+        48 => {
+            #[allow(clippy::expect_used)]
+            let bytes: &[u8; 48] = bytes.try_into().expect("we checked that bytes len == 48");
+            S::from_le_array_mod_order(bytes)
+        }
+        49.. => {
+            let two_to_384 = S::add(&S::from_le_array_mod_order(&[0xff; 48]), one);
+
+            let chunks = bytes.chunks_exact(48);
+            let remainder = if !chunks.remainder().is_empty() {
+                Some(scalar_from_le_bytes_mod_order_reducing_48::<S>(
+                    chunks.remainder(),
+                    one,
+                ))
+            } else {
+                None
+            };
+
+            let chunks = chunks.rev().map(|chunk| {
+                #[allow(clippy::expect_used)]
+                let chunk: &[u8; 48] = chunk.try_into().expect("wrong chunk size");
+                S::from_le_array_mod_order(chunk)
+            });
+
+            remainder
+                .into_iter()
+                .chain(chunks)
+                .reduce(|acc, int| S::add(&S::mul(&acc, &two_to_384), &int))
+                .unwrap_or_default()
+        }
+    }
+}
+
+/// Interprets `bytes` as big-endian encoding of an integer, takes it modulo curve (prime)
+/// order and returns scalar `S`
+///
+/// Works with scalars for which only [`Reduce<48>`][Reduce] is defined.
+///
+/// Takes:
+/// * Big-endian `bytes` representation of the integer
+/// * Scalar `one = 1`
+pub fn scalar_from_be_bytes_mod_order_reducing_48<S>(bytes: &[u8], one: &S) -> S
+where
+    S: Default + Copy,
+    S: Reduce<48>,
+    S: generic_ec_core::Additive + generic_ec_core::Multiplicative<S, Output = S>,
+{
+    let len = bytes.len();
+    match len {
+        ..=47 => {
+            let mut padded = [0u8; 48];
+            padded[48 - len..].copy_from_slice(bytes);
+            S::from_be_array_mod_order(&padded)
+        }
+        48 => {
+            #[allow(clippy::expect_used)]
+            let bytes: &[u8; 48] = bytes.try_into().expect("we checked that bytes len == 48");
+            S::from_be_array_mod_order(bytes)
+        }
+        49.. => {
+            let two_to_384 = S::add(&S::from_be_array_mod_order(&[0xff; 48]), one);
+
+            let chunks = bytes.rchunks_exact(48);
+            let remainder = if !chunks.remainder().is_empty() {
+                Some(scalar_from_be_bytes_mod_order_reducing_48::<S>(
+                    chunks.remainder(),
+                    one,
+                ))
+            } else {
+                None
+            };
+
+            let chunks = chunks.rev().map(|chunk| {
+                #[allow(clippy::expect_used)]
+                let chunk: &[u8; 48] = chunk.try_into().expect("wrong chunk size");
+                S::from_be_array_mod_order(chunk)
+            });
+
+            remainder
+                .into_iter()
+                .chain(chunks)
+                .reduce(|acc, int| S::add(&S::mul(&acc, &two_to_384), &int))
+                .unwrap_or_default()
+        }
+    }
+}
+
+/// Interprets `bytes` as little-endian encoding of an integer, takes it modulo curve (prime)
+/// order and returns scalar `S`
+///
 /// Works with scalars for which only [`Reduce<32>`][Reduce] is defined.
 ///
 /// Takes:

--- a/generic-ec-curves/src/utils.rs
+++ b/generic-ec-curves/src/utils.rs
@@ -133,216 +133,100 @@ where
 /// Interprets `bytes` as little-endian encoding of an integer, takes it modulo curve (prime)
 /// order and returns scalar `S`
 ///
-/// Works with scalars for which only [`Reduce<48>`][Reduce] is defined.
+/// Works with scalars for which [`Reduce<N>`][Reduce] is defined.
 ///
 /// Takes:
 /// * Little-endian `bytes` representation of the integer
 /// * Scalar `one = 1`
-pub fn scalar_from_le_bytes_mod_order_reducing_48<S>(bytes: &[u8], one: &S) -> S
+pub fn scalar_from_le_bytes_mod_order_reducing<S, const N: usize>(bytes: &[u8], one: &S) -> S
 where
     S: Default + Copy,
-    S: Reduce<48>,
+    S: Reduce<N>,
     S: generic_ec_core::Additive + generic_ec_core::Multiplicative<S, Output = S>,
 {
     let len = bytes.len();
-    match len {
-        ..=47 => {
-            let mut padded = [0u8; 48];
-            padded[..len].copy_from_slice(bytes);
-            S::from_le_array_mod_order(&padded)
-        }
-        48 => {
+    if len < N {
+        let mut padded = [0u8; N];
+        padded[..len].copy_from_slice(bytes);
+        S::from_le_array_mod_order(&padded)
+    } else if len == N {
+        #[allow(clippy::expect_used)]
+        let bytes: &[u8; N] = bytes.try_into().expect("we checked that bytes len == N");
+        S::from_le_array_mod_order(bytes)
+    } else {
+        let two_to_8n = S::add(&S::from_le_array_mod_order(&[0xff; N]), one);
+
+        let chunks = bytes.chunks_exact(N);
+        let remainder = if !chunks.remainder().is_empty() {
+            Some(scalar_from_le_bytes_mod_order_reducing::<S, N>(
+                chunks.remainder(),
+                one,
+            ))
+        } else {
+            None
+        };
+
+        let chunks = chunks.rev().map(|chunk| {
             #[allow(clippy::expect_used)]
-            let bytes: &[u8; 48] = bytes.try_into().expect("we checked that bytes len == 48");
-            S::from_le_array_mod_order(bytes)
-        }
-        49.. => {
-            let two_to_384 = S::add(&S::from_le_array_mod_order(&[0xff; 48]), one);
+            let chunk: &[u8; N] = chunk.try_into().expect("wrong chunk size");
+            S::from_le_array_mod_order(chunk)
+        });
 
-            let chunks = bytes.chunks_exact(48);
-            let remainder = if !chunks.remainder().is_empty() {
-                Some(scalar_from_le_bytes_mod_order_reducing_48::<S>(
-                    chunks.remainder(),
-                    one,
-                ))
-            } else {
-                None
-            };
-
-            let chunks = chunks.rev().map(|chunk| {
-                #[allow(clippy::expect_used)]
-                let chunk: &[u8; 48] = chunk.try_into().expect("wrong chunk size");
-                S::from_le_array_mod_order(chunk)
-            });
-
-            remainder
-                .into_iter()
-                .chain(chunks)
-                .reduce(|acc, int| S::add(&S::mul(&acc, &two_to_384), &int))
-                .unwrap_or_default()
-        }
+        remainder
+            .into_iter()
+            .chain(chunks)
+            .reduce(|acc, int| S::add(&S::mul(&acc, &two_to_8n), &int))
+            .unwrap_or_default()
     }
 }
 
 /// Interprets `bytes` as big-endian encoding of an integer, takes it modulo curve (prime)
 /// order and returns scalar `S`
 ///
-/// Works with scalars for which only [`Reduce<48>`][Reduce] is defined.
+/// Works with scalars for which [`Reduce<N>`][Reduce] is defined.
 ///
 /// Takes:
 /// * Big-endian `bytes` representation of the integer
 /// * Scalar `one = 1`
-pub fn scalar_from_be_bytes_mod_order_reducing_48<S>(bytes: &[u8], one: &S) -> S
+pub fn scalar_from_be_bytes_mod_order_reducing<S, const N: usize>(bytes: &[u8], one: &S) -> S
 where
     S: Default + Copy,
-    S: Reduce<48>,
+    S: Reduce<N>,
     S: generic_ec_core::Additive + generic_ec_core::Multiplicative<S, Output = S>,
 {
     let len = bytes.len();
-    match len {
-        ..=47 => {
-            let mut padded = [0u8; 48];
-            padded[48 - len..].copy_from_slice(bytes);
-            S::from_be_array_mod_order(&padded)
-        }
-        48 => {
+    if len < N {
+        let mut padded = [0u8; N];
+        padded[N - len..].copy_from_slice(bytes);
+        S::from_be_array_mod_order(&padded)
+    } else if len == N {
+        #[allow(clippy::expect_used)]
+        let bytes: &[u8; N] = bytes.try_into().expect("we checked that bytes len == N");
+        S::from_be_array_mod_order(bytes)
+    } else {
+        let two_to_8n = S::add(&S::from_be_array_mod_order(&[0xff; N]), one);
+
+        let chunks = bytes.rchunks_exact(N);
+        let remainder = if !chunks.remainder().is_empty() {
+            Some(scalar_from_be_bytes_mod_order_reducing::<S, N>(
+                chunks.remainder(),
+                one,
+            ))
+        } else {
+            None
+        };
+
+        let chunks = chunks.rev().map(|chunk| {
             #[allow(clippy::expect_used)]
-            let bytes: &[u8; 48] = bytes.try_into().expect("we checked that bytes len == 48");
-            S::from_be_array_mod_order(bytes)
-        }
-        49.. => {
-            let two_to_384 = S::add(&S::from_be_array_mod_order(&[0xff; 48]), one);
+            let chunk: &[u8; N] = chunk.try_into().expect("wrong chunk size");
+            S::from_be_array_mod_order(chunk)
+        });
 
-            let chunks = bytes.rchunks_exact(48);
-            let remainder = if !chunks.remainder().is_empty() {
-                Some(scalar_from_be_bytes_mod_order_reducing_48::<S>(
-                    chunks.remainder(),
-                    one,
-                ))
-            } else {
-                None
-            };
-
-            let chunks = chunks.rev().map(|chunk| {
-                #[allow(clippy::expect_used)]
-                let chunk: &[u8; 48] = chunk.try_into().expect("wrong chunk size");
-                S::from_be_array_mod_order(chunk)
-            });
-
-            remainder
-                .into_iter()
-                .chain(chunks)
-                .reduce(|acc, int| S::add(&S::mul(&acc, &two_to_384), &int))
-                .unwrap_or_default()
-        }
-    }
-}
-
-/// Interprets `bytes` as little-endian encoding of an integer, takes it modulo curve (prime)
-/// order and returns scalar `S`
-///
-/// Works with scalars for which only [`Reduce<32>`][Reduce] is defined.
-///
-/// Takes:
-/// * Little-endian `bytes` representation of the integer
-/// * Scalar `one = 1`
-pub fn scalar_from_le_bytes_mod_order_reducing_32<S>(bytes: &[u8], one: &S) -> S
-where
-    S: Default + Copy,
-    S: Reduce<32>,
-    S: generic_ec_core::Additive + generic_ec_core::Multiplicative<S, Output = S>,
-{
-    let len = bytes.len();
-    match len {
-        ..=31 => {
-            let mut padded = [0u8; 32];
-            padded[..len].copy_from_slice(bytes);
-            S::from_le_array_mod_order(&padded)
-        }
-        32 => {
-            #[allow(clippy::expect_used)]
-            let bytes: &[u8; 32] = bytes.try_into().expect("we checked that bytes len == 32");
-            S::from_le_array_mod_order(bytes)
-        }
-        33.. => {
-            let two_to_256 = S::add(&S::from_le_array_mod_order(&[0xff; 32]), one);
-
-            let chunks = bytes.chunks_exact(32);
-            let remainder = if !chunks.remainder().is_empty() {
-                Some(scalar_from_le_bytes_mod_order_reducing_32::<S>(
-                    chunks.remainder(),
-                    one,
-                ))
-            } else {
-                None
-            };
-
-            let chunks = chunks.rev().map(|chunk| {
-                #[allow(clippy::expect_used)]
-                let chunk: &[u8; 32] = chunk.try_into().expect("wrong chunk size");
-                S::from_le_array_mod_order(chunk)
-            });
-
-            remainder
-                .into_iter()
-                .chain(chunks)
-                .reduce(|acc, int| S::add(&S::mul(&acc, &two_to_256), &int))
-                .unwrap_or_default()
-        }
-    }
-}
-
-/// Interprets `bytes` as big-endian encoding of an integer, takes it modulo curve (prime)
-/// order and returns scalar `S`
-///
-/// Works with scalars for which only [`Reduce<32>`][Reduce] is defined.
-///
-/// Takes:
-/// * Big-endian `bytes` representation of the integer
-/// * Scalar `one = 1`
-pub fn scalar_from_be_bytes_mod_order_reducing_32<S>(bytes: &[u8], one: &S) -> S
-where
-    S: Default + Copy,
-    S: Reduce<32>,
-    S: generic_ec_core::Additive + generic_ec_core::Multiplicative<S, Output = S>,
-{
-    let len = bytes.len();
-    match len {
-        ..=31 => {
-            let mut padded = [0u8; 32];
-            padded[32 - len..].copy_from_slice(bytes);
-            S::from_be_array_mod_order(&padded)
-        }
-        32 => {
-            #[allow(clippy::expect_used)]
-            let bytes: &[u8; 32] = bytes.try_into().expect("we checked that bytes len == 32");
-            S::from_be_array_mod_order(bytes)
-        }
-        33.. => {
-            let two_to_256 = S::add(&S::from_be_array_mod_order(&[0xff; 32]), one);
-
-            let chunks = bytes.rchunks_exact(32);
-            let remainder = if !chunks.remainder().is_empty() {
-                Some(scalar_from_be_bytes_mod_order_reducing_32::<S>(
-                    chunks.remainder(),
-                    one,
-                ))
-            } else {
-                None
-            };
-
-            let chunks = chunks.rev().map(|chunk| {
-                #[allow(clippy::expect_used)]
-                let chunk: &[u8; 32] = chunk.try_into().expect("wrong chunk size");
-                S::from_be_array_mod_order(chunk)
-            });
-
-            remainder
-                .into_iter()
-                .chain(chunks)
-                .reduce(|acc, int| S::add(&S::mul(&acc, &two_to_256), &int))
-                .unwrap_or_default()
-        }
+        remainder
+            .into_iter()
+            .chain(chunks)
+            .reduce(|acc, int| S::add(&S::mul(&acc, &two_to_8n), &int))
+            .unwrap_or_default()
     }
 }
 
@@ -363,7 +247,7 @@ mod tests {
         );
         assert_eq!(
             expected,
-            super::scalar_from_be_bytes_mod_order_reducing_32(&x.to_be_bytes(), one).0
+            super::scalar_from_be_bytes_mod_order_reducing::<_, 32>(&x.to_be_bytes(), one).0
         );
 
         assert_eq!(
@@ -372,7 +256,7 @@ mod tests {
         );
         assert_eq!(
             expected,
-            super::scalar_from_le_bytes_mod_order_reducing_32(&x.to_le_bytes(), one).0
+            super::scalar_from_le_bytes_mod_order_reducing::<_, 32>(&x.to_le_bytes(), one).0
         );
     }
 }

--- a/generic-ec/Cargo.toml
+++ b/generic-ec/Cargo.toml
@@ -53,9 +53,10 @@ udigest = ["dep:udigest"]
 curves = ["generic-ec-curves"]
 curve-secp256k1 = ["curves", "generic-ec-curves/secp256k1"]
 curve-secp256r1 = ["curves", "generic-ec-curves/secp256r1"]
+curve-secp384r1 = ["curves", "generic-ec-curves/secp384r1"]
 curve-stark = ["curves", "generic-ec-curves/stark"]
 curve-ed25519 = ["curves", "generic-ec-curves/ed25519", "curve25519"]
-all-curves = ["curve-secp256k1", "curve-secp256r1", "curve-stark", "curve-ed25519"]
+all-curves = ["curve-secp256k1", "curve-secp256r1", "curve-secp384r1", "curve-stark", "curve-ed25519"]
 
 hash-to-scalar = ["dep:rand_hash", "dep:digest", "udigest"]
 

--- a/generic-ec/src/lib.rs
+++ b/generic-ec/src/lib.rs
@@ -184,7 +184,7 @@
 #![cfg_attr(not(test), forbid(unused_crate_dependencies))]
 #![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "std")]
 extern crate std;

--- a/generic-ec/src/lib.rs
+++ b/generic-ec/src/lib.rs
@@ -71,11 +71,13 @@
 //! |--------------|--------------------|-------------------|
 //! | secp256k1    | `curve-secp256k1`  | [RustCrypto/k256] |
 //! | secp256r1    | `curve-secp256r1`  | [RustCrypto/p256] |
+//! | secp384r1    | `curve-secp384r1`  | [RustCrypto/p384] |
 //! | stark-curve  | `curve-stark`      | [Dfns/stark]      |
 //! | Ed25519      | `curve-ed25519`    | [curve25519-dalek]|
 //!
 //! [RustCrypto/k256]: https://github.com/RustCrypto/elliptic-curves/tree/master/k256
 //! [RustCrypto/p256]: https://github.com/RustCrypto/elliptic-curves/tree/master/p256
+//! [RustCrypto/p384]: https://github.com/RustCrypto/elliptic-curves/tree/master/p384
 //! [Dfns/stark]: https://github.com/LFDT-Lockness/stark-curve/
 //! [curve25519-dalek]: https://docs.rs/curve25519-dalek/
 //!
@@ -277,6 +279,9 @@ pub mod curves {
     #[cfg(feature = "curve-secp256r1")]
     #[cfg_attr(docsrs, doc(cfg(feature = "curve-secp256r1")))]
     pub use generic_ec_curves::Secp256r1;
+    #[cfg(feature = "curve-secp384r1")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "curve-secp384r1")))]
+    pub use generic_ec_curves::Secp384r1;
     #[cfg(feature = "curve-stark")]
     #[cfg_attr(docsrs, doc(cfg(feature = "curve-stark")))]
     pub use generic_ec_curves::Stark;
@@ -351,6 +356,8 @@ pub mod curves {
         secp256k1: Secp256k1,
         #[cfg(feature = "curve-secp256r1")]
         secp256r1: Secp256r1,
+        #[cfg(feature = "curve-secp384r1")]
+        secp384r1: Secp384r1,
         #[cfg(feature = "curve-stark")]
         stark: Stark,
         #[cfg(feature = "curve-ed25519")]

--- a/generic-ec/src/multiscalar/straus.rs
+++ b/generic-ec/src/multiscalar/straus.rs
@@ -320,6 +320,8 @@ mod tests {
     mod secp256k1 {}
     #[instantiate_tests(<crate::curves::Secp256r1>)]
     mod secp256r1 {}
+    #[instantiate_tests(<crate::curves::Secp384r1>)]
+    mod secp384r1 {}
     #[instantiate_tests(<crate::curves::Stark>)]
     mod stark {}
     #[instantiate_tests(<crate::curves::Ed25519>)]

--- a/generic-ec/src/multiscalar/straus.rs
+++ b/generic-ec/src/multiscalar/straus.rs
@@ -186,7 +186,7 @@ impl<E: Curve> NafMatrix<E> {
     fn add_scalar(&mut self, scalar: &Scalar<E>) {
         let scalar_bytes = scalar.to_le_bytes();
         let mut x_u64 = vec![0u64; scalar_bytes.len() / 8 + 1];
-        read_le_u64_into(&scalar_bytes, &mut x_u64[0..4]);
+        read_le_u64_into(&scalar_bytes, &mut x_u64[0..scalar_bytes.len() / 8]);
 
         let offset = self.matrix.len();
         debug_assert!(

--- a/tests/benches/multiscalar.rs
+++ b/tests/benches/multiscalar.rs
@@ -15,6 +15,7 @@ fn multiscalar(c: &mut criterion::Criterion) {
 
     multiscalar_for_curve::<curves::Secp256k1>(c, &mut rng, "secp256k1");
     multiscalar_for_curve::<curves::Secp256r1>(c, &mut rng, "secp256r1");
+    multiscalar_for_curve::<curves::Secp384r1>(c, &mut rng, "secp384r1");
     multiscalar_for_curve::<curves::Stark>(c, &mut rng, "stark");
     multiscalar_for_curve::<curves::Ed25519>(c, &mut rng, "ed25519");
 

--- a/tests/benches/random.rs
+++ b/tests/benches/random.rs
@@ -8,6 +8,7 @@ fn random(c: &mut criterion::Criterion) {
 
     random_for_curve::<curves::Secp256k1>(c, &mut rng, "secp256k1");
     random_for_curve::<curves::Secp256r1>(c, &mut rng, "secp256r1");
+    random_for_curve::<curves::Secp384r1>(c, &mut rng, "secp384r1");
     random_for_curve::<curves::Stark>(c, &mut rng, "stark");
     random_for_curve::<curves::Ed25519>(c, &mut rng, "ed25519");
 }

--- a/tests/tests/curves.rs
+++ b/tests/tests/curves.rs
@@ -248,6 +248,9 @@ mod tests {
     #[instantiate_tests(<Secp256r1>)]
     mod secp256r1 {}
 
+    #[instantiate_tests(<Secp384r1>)]
+    mod secp384r1 {}
+
     #[instantiate_tests(<Stark>)]
     mod stark {}
 
@@ -287,6 +290,9 @@ mod scalar_reduce {
     #[instantiate_tests(<generic_ec::curves::Secp256r1, 32>)]
     mod secp256r1_32 {}
 
+    #[instantiate_tests(<generic_ec::curves::Secp384r1, 48>)]
+    mod secp384r1_48 {}
+
     #[instantiate_tests(<generic_ec::curves::Stark, 32>)]
     mod stark_32 {}
 
@@ -299,7 +305,7 @@ mod scalar_reduce {
 #[generic_tests::define]
 mod coordinates {
     use generic_ec::coords::{HasAffineX, HasAffineXAndParity, HasAffineXY, HasAffineY};
-    use generic_ec::curves::{Secp256k1, Secp256r1, Stark};
+    use generic_ec::curves::{Secp256k1, Secp256r1, Secp384r1, Stark};
     use generic_ec::{Curve, Point, Scalar};
 
     use rand_dev::DevRng;
@@ -352,6 +358,9 @@ mod coordinates {
 
     #[instantiate_tests(<Secp256r1>)]
     mod secp256r1 {}
+
+    #[instantiate_tests(<Secp384r1>)]
+    mod secp384r1 {}
 
     #[instantiate_tests(<Stark>)]
     mod stark {}

--- a/tests/tests/dlog_eq.rs
+++ b/tests/tests/dlog_eq.rs
@@ -40,6 +40,8 @@ mod interactive {
     mod secp256k1 {}
     #[instantiate_tests(<generic_ec::curves::Secp256r1>)]
     mod secp256r1 {}
+    #[instantiate_tests(<generic_ec::curves::Secp384r1>)]
+    mod secp384r1 {}
     #[instantiate_tests(<generic_ec::curves::Stark>)]
     mod stark {}
     #[instantiate_tests(<generic_ec::curves::Ed25519>)]
@@ -84,6 +86,8 @@ mod non_interactive {
     mod secp256k1_sha256 {}
     #[instantiate_tests(<generic_ec::curves::Secp256r1, sha2::Sha256>)]
     mod secp256r1_sha256 {}
+    #[instantiate_tests(<generic_ec::curves::Secp384r1, sha2::Sha256>)]
+    mod secp384r1_sha256 {}
     #[instantiate_tests(<generic_ec::curves::Stark, sha2::Sha256>)]
     mod stark_sha256 {}
     #[instantiate_tests(<generic_ec::curves::Ed25519, sha2::Sha256>)]

--- a/tests/tests/multiscalar.rs
+++ b/tests/tests/multiscalar.rs
@@ -3,7 +3,7 @@ mod tests {
     use core::iter;
 
     use generic_ec::{
-        curves::{Ed25519, Secp256k1, Secp256r1, Stark},
+        curves::{Ed25519, Secp256k1, Secp256r1, Secp384r1, Stark},
         multiscalar::{Dalek, MultiscalarMul, Naive, Straus},
         Curve, Point, Scalar,
     };
@@ -35,6 +35,8 @@ mod tests {
     mod secp256k1_straus {}
     #[instantiate_tests(<Secp256r1, Straus>)]
     mod secp256r1_straus {}
+    #[instantiate_tests(<Secp384r1, Straus>)]
+    mod secp384r1_straus {}
     #[instantiate_tests(<Stark, Straus>)]
     mod stark_straus {}
     #[instantiate_tests(<Ed25519, Straus>)]

--- a/tests/tests/serde.rs
+++ b/tests/tests/serde.rs
@@ -418,6 +418,9 @@ mod tests {
     #[instantiate_tests(<generic_ec::curves::Secp256r1>)]
     mod secp256r1 {}
 
+    #[instantiate_tests(<generic_ec::curves::Secp384r1>)]
+    mod secp384r1 {}
+
     #[instantiate_tests(<generic_ec::curves::Stark>)]
     mod stark {}
 }


### PR DESCRIPTION
## Summary

Hey! Following up on the discussion in #lockness-contribute and the plan laid out in #58 — this PR adds secp384r1 (NIST P-384) as the first curve with a larger scalar size (48 bytes / 384 bits) to the library.

The goal here was to actually plug in a bigger curve, run the full test suite against it, and see what breaks. The good news is: nothing broke. The existing scalar pipeline and the Straus NAF fix from #57 handle the 48-byte scalars cleanly.

### What's in here

- **p384 crate wired in** — new `secp384r1` feature flag through both `generic-ec-curves` and `generic-ec`, following the same RustCrypto pattern as the existing curves
- **Scalar traits implemented** — `CurveName`, `FromUniformBytes` (L=64 bytes per RFC 9380), `BytesModOrder`, `Reduce<48>` via `U384`, and `NoInvalidPoints`
- **New reduction utilities** — `scalar_from_{be,le}_bytes_mod_order_reducing_48` for Horner-method mod-order reduction using 48-byte chunks (same pattern as the `_reducing_32` variants)
- **Every test instantiated for secp384r1** — scalar ops, point ops, serde round-trips, Straus multiscalar multiplication, affine coordinates, dlog_eq ZK proofs, `Reduce<48>`, and `from_bytes_mod_order` with various input sizes
- **Benchmarks added** for the new curve

### Test results

All 180 tests pass, including all the new secp384r1 ones. Clippy is clean too. No hardcoded scalar-size assumptions surfaced beyond the one already fixed in #57.

### What's next (per the plan in #58)

- Look at adding more curves with different scalar sizes (curve448, P-521) to stress-test further
- Update `cggmp24` and `givre` to use these curves and make sure their tests pass
- Do a careful review for any remaining scalar-size assumptions that the test suite might not cover

Happy to adjust anything based on your feedback!

Relates to #58
Depends on #57

## Test plan

- [x] `cargo test --all-features` — 180/180 tests pass
- [x] `cargo clippy --all-features` — no warnings
- [x] Scalar byte round-trips (BE/LE) work for 48-byte scalars
- [x] `from_bytes_mod_order` works with various input lengths (8, 16, 32, 48, 64, 80, 96, 128, 256, 512 bytes and random lengths)
- [x] Straus multiscalar multiplication works with 384-bit NAFs
- [x] Serde serialization/deserialization round-trips
- [x] Affine coordinate access (x, y, parity) works
- [x] dlog_eq zero-knowledge proofs pass (both interactive and non-interactive)