### PR TITLE
feat(zkp): enforce NonZero scalar for dlog_eq generators

### DIFF
--- a/generic-ec-zkp/src/dlog_eq.rs
+++ b/generic-ec-zkp/src/dlog_eq.rs
@@ -90,18 +90,18 @@
 //!     .expect("Verification failed!");
 //! ```
 
-use generic_ec::{Curve, Point};
+use generic_ec::{Curve, NonZero, Point};
 
 /// Object of the proof: `log_gen1 prod1 == log_gen2 prod2`
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "udigest", derive(udigest::Digestable), udigest(bound = ""))]
 pub struct Data<E: Curve> {
     /// `G`, a generator, in multiplicative notation the base for one logarithm
-    pub gen1: Point<E>,
+    pub gen1: NonZero<Point<E>>,
     /// `X`, a point `G * x`, in multiplicative notation the value inside one logarithm
     pub prod1: Point<E>,
     /// `H`, a generator, in multiplicative notation the base for the other logarithm
-    pub gen2: Point<E>,
+    pub gen2: NonZero<Point<E>>,
     /// `Z`, a point `H * x`, in multiplicative notation the value inside the other logarithm
     pub prod2: Point<E>,
 }
@@ -111,9 +111,9 @@ impl<E: Curve> Data<E> {
     /// generator, and `x` is a secret key
     ///
     /// In this case, we set `H = gen` as gen2 and `Z = G * x` as prod2
-    pub fn from_secret_key(x: &generic_ec::SecretScalar<E>, gen: Point<E>) -> Data<E> {
+    pub fn from_secret_key(x: &generic_ec::SecretScalar<E>, gen: NonZero<Point<E>>) -> Data<E> {
         Self {
-            gen1: Point::generator().into(),
+            gen1: Point::generator().to_nonzero_point(),
             prod1: Point::generator() * x,
             gen2: gen,
             prod2: gen * x,
@@ -145,8 +145,8 @@ pub mod interactive {
     /// `rng` is used to generate the nonce for the private commitment
     pub fn commit<E: Curve>(
         rng: &mut (impl rand_core::RngCore + rand_core::CryptoRng),
-        gen1: Point<E>,
-        gen2: Point<E>,
+        gen1: NonZero<Point<E>>,
+        gen2: NonZero<Point<E>>,
     ) -> (Commitment<E>, PrivateCommitment<E>) {
         let r = Scalar::random(rng);
         let comm = (gen1 * r, gen2 * r);

--- a/tests/tests/dlog_eq.rs
+++ b/tests/tests/dlog_eq.rs
@@ -8,7 +8,7 @@ mod interactive {
 
         let secret_share = generic_ec::SecretScalar::<E>::random(&mut rng);
 
-        let base = generic_ec::Point::generator() * generic_ec::Scalar::random(&mut rng);
+        let base = generic_ec::NonZero::from_point(generic_ec::Point::generator() * generic_ec::Scalar::random(&mut rng)).unwrap();
         let data = dlog_eq::Data::from_secret_key(&secret_share, base);
 
         let (comm, pcomm) = dlog_eq::commit_data(&mut rng, data);
@@ -22,7 +22,7 @@ mod interactive {
 
         let secret_share = generic_ec::SecretScalar::<E>::random(&mut rng);
 
-        let base = generic_ec::Point::generator() * generic_ec::Scalar::random(&mut rng);
+        let base = generic_ec::NonZero::from_point(generic_ec::Point::generator() * generic_ec::Scalar::random(&mut rng)).unwrap();
         let mut data = dlog_eq::Data::from_secret_key(&secret_share, base);
         // Replace the exponentiation with something wrong
         data.prod2 += generic_ec::Point::generator();
@@ -59,7 +59,7 @@ mod non_interactive {
 
         let secret_share = generic_ec::SecretScalar::random(&mut rng);
 
-        let base = generic_ec::Point::generator() * generic_ec::Scalar::random(&mut rng);
+        let base = generic_ec::NonZero::from_point(generic_ec::Point::generator() * generic_ec::Scalar::random(&mut rng)).unwrap();
         let data = dlog_eq::Data::from_secret_key(&secret_share, base);
 
         let proof = dlog_eq::prove::<E, D>(&mut rng, &shared_state, &secret_share, data);
@@ -73,7 +73,7 @@ mod non_interactive {
 
         let secret_share = generic_ec::SecretScalar::random(&mut rng);
 
-        let base = generic_ec::Point::generator() * generic_ec::Scalar::random(&mut rng);
+        let base = generic_ec::NonZero::from_point(generic_ec::Point::generator() * generic_ec::Scalar::random(&mut rng)).unwrap();
         let mut data = dlog_eq::Data::from_secret_key(&secret_share, base);
         // make exp2 wrong so that proof won't hold
         data.prod2 += generic_ec::Point::generator();


### PR DESCRIPTION
Fixes LFDT-Lockness/generic-ec#56

Currently, the `dlog_eq` protocol accepts `Point<E>` for generators, which does not guarantee that the generator is non-zero at compile-time. If a zero point is somehow passed as a generator, the zero-knowledge proof becomes degenerate. 

This PR updates the `Data` struct, the `commit` functions, and the `from_secret_key` constructor to strictly require `NonZero<Point<E>>` as input. I have also updated the interactive and non-interactive tests to safely use `.unwrap()` when wrapping randomly generated points using `NonZero::from_point`.
