### PR TITLE
Const-time integer conversion

### DIFF
--- a/generic-ec/src/scalar.rs
+++ b/generic-ec/src/scalar.rs
@@ -380,16 +380,19 @@ macro_rules! impl_from_primitive_integer {
 }
 
 macro_rules! impl_from_signed_integer {
-    ($($iint:ident),+) => {$(
+    ($($iint:ident => $uint:ident),+ $(,)?) => {$(
         impl<E: Curve> From<$iint> for Scalar<E> {
             fn from(i: $iint) -> Self {
-                use subtle::{ConditionallyNegatable, Choice};
-                // TODO: what's a better way to do that check in constant time?
-                let is_neg = Choice::from(u8::from(i.is_negative()));
-                let i = i.unsigned_abs();
-                let mut i = Scalar::from(i);
-                i.conditional_negate(is_neg);
-                i
+                use subtle::{Choice, ConditionallyNegatable};
+                const BITS: u32 = <$iint>::BITS;
+                let x = i as $uint;
+                let mask = (x >> (BITS - 1)).wrapping_neg();
+                let abs = x.wrapping_add(mask) ^ mask;
+                let mut scalar = Scalar::from(abs);
+                scalar.conditional_negate(
+                    Choice::from((mask >> (BITS - 1)) as u8)
+                );
+                scalar
             }
         }
     )+};
@@ -399,7 +402,12 @@ impl_from_primitive_integer! {
     u8, u16, u32, u64, u128, usize
 }
 impl_from_signed_integer! {
-    i8, i16, i32, i64, i128
+    i8 => u8,
+    i16 => u16,
+    i32 => u32,
+    i64 => u64,
+    i128 => u128,
+    isize => usize
 }
 
 impl<E: Curve> fmt::Debug for Scalar<E> {

--- a/tests/tests/curves.rs
+++ b/tests/tests/curves.rs
@@ -76,6 +76,23 @@ mod tests {
     }
 
     #[test]
+    fn scalar_from_signed_min<E: Curve>() {
+        assert_eq!(Scalar::<E>::from(i8::MIN), Scalar::<E>::zero() - Scalar::from(i8::MIN.unsigned_abs()));
+        assert_eq!(Scalar::<E>::from(i16::MIN), Scalar::<E>::zero() - Scalar::from(i16::MIN.unsigned_abs()));
+        assert_eq!(Scalar::<E>::from(i32::MIN), Scalar::<E>::zero() - Scalar::from(i32::MIN.unsigned_abs()));
+        assert_eq!(Scalar::<E>::from(i64::MIN), Scalar::<E>::zero() - Scalar::from(i64::MIN.unsigned_abs()));
+        assert_eq!(Scalar::<E>::from(i128::MIN), Scalar::<E>::zero() - Scalar::from(i128::MIN.unsigned_abs()));
+        assert_eq!(Scalar::<E>::from(isize::MIN),Scalar::<E>::zero() - Scalar::from(isize::MIN.unsigned_abs())
+    );
+    }
+    #[test]
+    fn scalar_from_minus_one<E: Curve>() {
+        assert_eq!(
+            Scalar::<E>::from(-1i32),
+            Scalar::<E>::zero() - Scalar::<E>::one()
+        )
+    }
+    #[test]
     fn scalar_invert<E: Curve>() {
         let mut rng = DevRng::new();
 


### PR DESCRIPTION
Summary
Fixes #67 
This PR improves the current implementation of signed integer conversions for Scalar<E> by replacing the previous approach based on: i.is_negative(), i.unsigned_abs() with a branchless two’s-complement formulation using unsigned arithmetic and wrapping operations.
The new implementation uses canonical constant-time bit-manipulation patterns, preserves correct handling of iN::MIN
and improves auditability/readability for cryptographic review

Changes:
impl<E: Curve> From<iN> for Scalar<E> uses branchless unsigned arithmetic for sign extraction and absolute value computation. The implementation now derives a sign mask,  a branchless absolute value, constant-time conditional negation, without using is_negative() or unsigned_abs() internally.
Also added support for isize => usize in the conversion macro.

Tests
Added regression tests covering edge cases for signed integer conversion:
i8::MIN
i16::MIN
i32::MIN
i64::MIN
i128::MIN
-1
Comments for mentor:
I am raising a draft pr to show a potential change, if any changes need to be made or someone has any other ideas  I'll be happy to modify this.