### PR TITLE
Fix cargo-rdme CI

### DIFF
--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   pull_request:
     branches: [ "*" ]
-    
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_NET_GIT_FETCH_WITH_CLI: true
@@ -17,9 +17,10 @@ jobs:
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
     - name: Install cargo-rdme
-      uses: baptiste0928/cargo-install@77fc781ff2a66b362d815793ec7bd69b50d0e549 #v1
+      uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 #v3.4.0
       with:
         crate: cargo-rdme
+        version: "=1.5.1"
     - name: Check that readme matches lib.rs
       run: |
         (cd generic-ec; cargo rdme -r ../README.md --check)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -126,7 +126,7 @@ jobs:
       run:
         cargo check -p generic-ec --target wasm32-unknown-unknown --features all-curves
     - name: Install wasm-pack
-      uses: baptiste0928/cargo-install@77fc781ff2a66b362d815793ec7bd69b50d0e549 #v1
+      uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 #v3.4.0
       with:
         crate: wasm-pack
     - name: wasm-pack an example project


### PR DESCRIPTION
Pin the crate to the older version which worked fine and did not have this problem. Also bump the cargo-install package as it had a deprecation warning